### PR TITLE
Show the filename at the top with the title

### DIFF
--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -16,11 +16,6 @@
       <td>{{ template "snippet_location" .Data.Address }}</td>
     </tr>
     <tr>
-      <td class="{{ IconFor `file` }}"></td>
-      <th>{{ i18n "File" }}</th>
-      <td>{{ .Filename }}</td>
-    </tr>
-    <tr>
       <td class="{{ IconFor `source` }}"></td>
       <th>{{ i18n "Source" }}</th>
       <td>{{ .Data.Creator }}</td>

--- a/views/workouts/workouts_edit.html
+++ b/views/workouts/workouts_edit.html
@@ -8,7 +8,9 @@
     <div class="content">
       {{ with .workout }}
       <div class="gap-4">
-        <h2 class="{{ IconFor .Type.String }}">{{ .Name }}</h2>
+        <h2 class="{{ IconFor .Type.String }}">
+          {{ .Name }} {{ with .Filename }}({{ . }}){{ end }}
+        </h2>
       </div>
       <div class="sm:flex sm:flex-wrap">
         <div class="basis-1/2">

--- a/views/workouts/workouts_show.html
+++ b/views/workouts/workouts_show.html
@@ -27,7 +27,9 @@
         </span>
         {{ end }}
 
-        <h2 class="{{ IconFor .Type.String }}">{{ .Name }}</h2>
+        <h2 class="{{ IconFor .Type.String }}">
+          {{ .Name }} {{ with .Filename }}({{ . }}){{ end }}
+        </h2>
       </div>
       <div class="sm:flex sm:flex-wrap">
         <div class="basis-1/2">


### PR DESCRIPTION
The filename can be a long string with no spaces, which messes with the details tabel size. Moving this to the top, seems like a reasonable compromise for now.