### PR TITLE
fix: deal correctly with GPX files that have multiple segments and count time between segments as pause time

### DIFF
--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -160,15 +160,10 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 		return nil
 	}
 
-	var totalDistance float64 = 0.0
-	var totalDuration time.Duration
-	var pauseDuration time.Duration
-	var minElevation float64 = 0.0
-	var maxElevation float64 = 0.0
-	var uphill float64 = 0.0
-	var downhill float64 = 0.0
-	var maxSpeed float64 = 0.0
-	var lastSegmentEnd *gpx.GPXPoint
+	var (
+		totalDistance, maxElevation, minElevation, uphill, downhill, maxSpeed float64
+		totalDuration, pauseDuration                                          time.Duration
+	)
 
 	for _, track := range gpxContent.Tracks {
 		for _, segment := range track.Segments {
@@ -181,17 +176,6 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 				uphill += segment.UphillDownhill().Uphill
 				downhill += segment.UphillDownhill().Downhill
 				maxSpeed = max(maxSpeed, segment.MovingData().MaxSpeed)
-
-				firstPoint := &segment.Points[0]
-				if lastSegmentEnd != nil {
-					// Calculate time between this segment's first point and last segment's last point, and add to pause time
-					pauseDuration += firstPoint.Timestamp.Sub(lastSegmentEnd.Timestamp)
-					pauseDistance := lastSegmentEnd.Point.Distance3D(&firstPoint.Point)
-					totalDistance -= pauseDistance
-				}
-
-				lastPoint := &segment.Points[len(segment.Points)-1]
-				lastSegmentEnd = lastPoint
 			}
 		}
 	}

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -168,7 +168,7 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 	var uphill float64 = 0.0
 	var downhill float64 = 0.0
 	var maxSpeed float64 = 0.0
-	var lastSegmentEnd *time.Time
+	var lastSegmentEnd *gpx.GPXPoint
 
 	for _, track := range gpxContent.Tracks {
 		for _, segment := range track.Segments {
@@ -185,11 +185,13 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 				firstPoint := &segment.Points[0]
 				if lastSegmentEnd != nil {
 					// Calculate time between this segment's first point and last segment's last point, and add to pause time
-					pauseDuration += firstPoint.Timestamp.Sub(*lastSegmentEnd)
+					pauseDuration += firstPoint.Timestamp.Sub(lastSegmentEnd.Timestamp)
+					pauseDistance := lastSegmentEnd.Point.Distance3D(&firstPoint.Point)
+					totalDistance -= pauseDistance
 				}
 
 				lastPoint := &segment.Points[len(segment.Points)-1]
-				lastSegmentEnd = &lastPoint.Timestamp
+				lastSegmentEnd = lastPoint
 			}
 		}
 	}

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -163,6 +163,7 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 	var (
 		totalDistance, maxElevation, minElevation, uphill, downhill, maxSpeed float64
 		totalDuration, pauseDuration                                          time.Duration
+		lastSegmentEnd                                                        *gpx.GPXPoint
 	)
 
 	for _, track := range gpxContent.Tracks {
@@ -176,6 +177,15 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 				uphill += segment.UphillDownhill().Uphill
 				downhill += segment.UphillDownhill().Downhill
 				maxSpeed = max(maxSpeed, segment.MovingData().MaxSpeed)
+
+				firstPoint := &segment.Points[0]
+				if lastSegmentEnd != nil {
+					// Calculate time between this segment's first point and last segment's last point, and add to pause time
+					pauseDuration += firstPoint.Timestamp.Sub(lastSegmentEnd.Timestamp)
+				}
+
+				lastPoint := &segment.Points[len(segment.Points)-1]
+				lastSegmentEnd = lastPoint
 			}
 		}
 	}


### PR DESCRIPTION
Workoutdoors generates multiple segments in a track (`<trkseg>`) when pausing along the way. 

This change ensures all segments are included and counts the time passed between segments as pause time.