### PR TITLE
Do not apply altitude correction for files from Workoutdoors (Apple Watch)

### DIFF
--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -12,7 +12,7 @@ import (
 var online = true
 
 func creatorNeedsCorrection(creator string) bool {
-	return creator != "Garmin Connect"
+	return creator != "Garmin Connect" && creator != "Apple Watch"
 }
 
 func correctAltitude(creator string, lat, long, alt float64) float64 {


### PR DESCRIPTION
This disables altitude correction for GPXes from Workoutdoors. It uses `creator="Apple Watch"` so it might mess with other apps from Apple Watch that *do* need correction (I don't know if these exist).