### PR TITLE
fix: format tempo as mm:s (where s is seconds)

### DIFF
--- a/pkg/templatehelpers/template_funcs.go
+++ b/pkg/templatehelpers/template_funcs.go
@@ -3,6 +3,7 @@ package templatehelpers
 import (
 	"fmt"
 	"html/template"
+	"math"
 	"strings"
 	"time"
 
@@ -47,7 +48,10 @@ func HumanTempo(mps float64) string {
 	mpk := 1000000 / (mps * 60)
 	value, prefix := humanize.ComputeSI(mpk)
 
-	return fmt.Sprintf("%.2f min/%sm", value, prefix)
+	wholeMinutes := math.Floor(value)
+	seconds := (value - wholeMinutes) * 60
+
+	return fmt.Sprintf("%d:%02d min/%sm", int(wholeMinutes), int(seconds), prefix)
 }
 
 func BoolToHTML(b bool) template.HTML {

--- a/pkg/templatehelpers/template_funcs_test.go
+++ b/pkg/templatehelpers/template_funcs_test.go
@@ -44,9 +44,10 @@ func TestHumanSpeed(t *testing.T) {
 }
 
 func TestHumanTempo(t *testing.T) {
-	assert.Equal(t, "13.55 min/km", HumanTempo(1.23))
-	assert.Equal(t, "6.00 min/km", HumanTempo(2.78))
-	assert.Equal(t, "3.34 min/km", HumanTempo(4.99))
+	assert.Equal(t, "13:33 min/km", HumanTempo(1.23))
+	assert.Equal(t, "5:59 min/km", HumanTempo(2.78))
+	assert.Equal(t, "3:20 min/km", HumanTempo(4.99))
+	assert.Equal(t, "5:01 min/km", HumanTempo(3.32))
 }
 
 func TestBoolToHTML(t *testing.T) {


### PR DESCRIPTION
The mm:ss format is a bit more intuitive (for me/as runner at least) than the m.f format (where f is a fraction of a minute)