### PR TITLE
WIP: perf: do not fetch all data for workouts to speed up rendering the workout list

### DIFF
--- a/pkg/app/data.go
+++ b/pkg/app/data.go
@@ -77,7 +77,7 @@ func (a *App) addWorkouts(u *database.User, data map[string]interface{}) error {
 		return nil
 	}
 
-	w, err := u.GetWorkouts(a.db)
+	w, err := u.GetWorkoutsAPI(a.db)
 	if err != nil {
 		return err
 	}

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -204,6 +204,16 @@ func (u *User) GetWorkouts(db *gorm.DB) ([]*Workout, error) {
 	return w, nil
 }
 
+func (u *User) GetWorkoutsAPI(db *gorm.DB) ([]*WorkoutAPI, error) {
+	var w []*WorkoutAPI
+
+	if err := db.Model(&Workout{}).Where(&Workout{UserID: u.ID}).Order("date DESC").Find(&w).Error; err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
 func (u *User) AddWorkout(db *gorm.DB, workoutType WorkoutType, notes string, filename string, content []byte) (*Workout, error) {
 	if u == nil {
 		return nil, ErrNoUser

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -12,6 +12,20 @@ import (
 
 var ErrInvalidData = errors.New("could not convert data to a GPX structure")
 
+// Workout type excluding the larger fields to speed up querying for lists
+type WorkoutAPI struct {
+	gorm.Model
+	Name     string     `gorm:"nut null"`
+	Date     *time.Time `gorm:"not null"`
+	UserID   uint       `gorm:"not null;index"`
+	Dirty    bool
+	User     *User
+	Notes    string
+	Type     WorkoutType
+	Data     *MapData `gorm:"serializer:json"`
+	Filename string
+}
+
 type Workout struct {
 	gorm.Model
 	Name     string     `gorm:"nut null"`


### PR DESCRIPTION
When loading the workout list, the app fetches basically the full `workouts` table including all GPX data. This seems a bit unnecessary and also is very slow. This PR fixes it partially by omitting certain fields. However, the `Data` field is still quite large (while the list only uses some statistics). Further work should probaby be done to split the `Data` field into a `Details` field (containing e.g. all the points) and a `Statistics` field containing the basic stats.

This change makes the query a full second faster on my data set (~400 workouts).

Before:

````
12:14PM WRN slow sql query [4.46089625s >= 100ms] app=workout-tracker version=local sha=local module=database slow_query=true query="SELECT * FROM `workouts` WHERE `workouts`.`user_id` = 1 AND `workouts`.`deleted_at` IS NULL ORDER BY date DESC" duration=4.46089625s rows=412 file=/Users/tommy/Repos/workout-tracker/pkg/database/user.go:200
````

After:

````
12:40PM WRN slow sql query [3.434046834s >= 100ms] app=workout-tracker version=local sha=local module=database slow_query=true query="SELECT `workouts`.`id`,`workouts`.`created_at`,`workouts`.`updated_at`,`workouts`.`deleted_at`,`workouts`.`name`,`workouts`.`date`,`workouts`.`user_id`,`workouts`.`dirty`,`workouts`.`notes`,`workouts`.`type`,`workouts`.`data`,`workouts`.`filename` FROM `workouts` WHERE `workouts`.`user_id` = 1 AND `workouts`.`deleted_at` IS NULL ORDER BY date DESC" duration=3.434046834s rows=412 file=/Users/tommy/Repos/workout-tracker/pkg/database/user.go:210
````