### PR TITLE
Move original content of GPX file to separate table

### DIFF
--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -197,7 +197,7 @@ func (u *User) Delete(db *gorm.DB) error {
 func (u *User) GetWorkout(db *gorm.DB, id int) (*Workout, error) {
 	var w *Workout
 
-	if err := db.Where(&Workout{UserID: u.ID}).First(&w, id).Error; err != nil {
+	if err := db.Preload("GPX").Where(&Workout{UserID: u.ID}).First(&w, id).Error; err != nil {
 		return nil, err
 	}
 

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -14,17 +14,35 @@ var ErrInvalidData = errors.New("could not convert data to a GPX structure")
 
 type Workout struct {
 	gorm.Model
-	Name     string     `gorm:"nut null"`
-	Date     *time.Time `gorm:"not null"`
-	UserID   uint       `gorm:"not null;index"`
-	Dirty    bool
-	User     *User
-	Notes    string
-	Type     WorkoutType
-	Data     *MapData `gorm:"serializer:json"`
-	Checksum []byte   `gorm:"not null;uniqueIndex"`
-	GPXData  []byte   `gorm:"type:mediumtext"`
+	Name   string     `gorm:"not null"`
+	Date   *time.Time `gorm:"not null"`
+	UserID uint       `gorm:"not null;index"`
+	Dirty  bool
+	User   *User
+	Notes  string
+	Type   WorkoutType
+	Data   *MapData `gorm:"serializer:json"`
+	GPX    *GPXData
+
+	GPXData  []byte `gorm:"type:mediumtext"`
 	Filename string
+	Checksum []byte
+}
+
+type GPXData struct {
+	gorm.Model
+	WorkoutID uint   `gorm:"not null;uniqueIndex"`
+	Content   []byte `gorm:"type:mediumtext"`
+	Checksum  []byte `gorm:"not null;uniqueIndex"`
+	Filename  string
+}
+
+func (d *GPXData) Save(db *gorm.DB) error {
+	if d.Content == nil {
+		return ErrInvalidData
+	}
+
+	return db.Save(d).Error
 }
 
 func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string, content []byte) (*Workout, error) {
@@ -47,16 +65,18 @@ func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string,
 	}
 
 	w := Workout{
-		User:     u,
-		UserID:   u.ID,
-		GPXData:  content,
-		Name:     gpxName(gpxContent),
-		Data:     data,
-		Notes:    notes,
-		Type:     workoutType,
-		Date:     gpxDate(gpxContent),
-		Checksum: h.Sum(nil),
-		Filename: filename,
+		User:   u,
+		UserID: u.ID,
+		Name:   gpxName(gpxContent),
+		Data:   data,
+		Notes:  notes,
+		Type:   workoutType,
+		Date:   gpxDate(gpxContent),
+		GPX: &GPXData{
+			Content:  content,
+			Checksum: h.Sum(nil),
+			Filename: filename,
+		},
 	}
 
 	return &w, nil
@@ -78,6 +98,16 @@ func GetRecentWorkouts(db *gorm.DB, count int) ([]Workout, error) {
 	var w []Workout
 
 	if err := db.Preload("User").Order("date DESC").Limit(count).Find(&w).Error; err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+func GetWorkouts(db *gorm.DB) ([]*Workout, error) {
+	var w []*Workout
+
+	if err := db.Order("date DESC").Find(&w).Error; err != nil {
 		return nil, err
 	}
 
@@ -115,7 +145,7 @@ func (w *Workout) Save(db *gorm.DB) error {
 }
 
 func (w *Workout) AsGPX() (*gpx.GPX, error) {
-	return converters.Parse(w.Filename, w.GPXData)
+	return converters.Parse(w.GPX.Filename, w.GPX.Content)
 }
 
 func (w *Workout) UpdateData(db *gorm.DB) error {


### PR DESCRIPTION
This should auto-migrate the current content, and clear the columns in the workouts table.