### PR TITLE
fix: prevent number and units from being wrapped

### DIFF
--- a/views/partials/workout_breakdown.html
+++ b/views/partials/workout_breakdown.html
@@ -30,8 +30,8 @@
       </td>
       <td class="text-center">{{ .Counter }}</td>
       <td>{{ .Duration }}</td>
-      <td class="whitespace-nowrap">{{ .Speed | HumanSpeed }}</td>
-      <td class="whitespace-nowrap">{{ .Speed | HumanTempo }}</td>
+      <td class="whitespace-nowrap font-mono">{{ .Speed | HumanSpeed }}</td>
+      <td class="whitespace-nowrap font-mono">{{ .Speed | HumanTempo }}</td>
     </tr>
     {{ end }}
   </tbody>
@@ -40,7 +40,9 @@
       <td colspan="2"></td>
       <td colspan="3">
         {{ i18n "Last distance" }}:
-        <span class="whitespace-nowrap">{{ $distance | HumanDistance }}</span>
+        <span class="whitespace-nowrap font-mono"
+          >{{ $distance | HumanDistance }}</span
+        >
       </td>
     </tr>
   </tfoot>

--- a/views/partials/workout_breakdown.html
+++ b/views/partials/workout_breakdown.html
@@ -30,8 +30,8 @@
       </td>
       <td class="text-center">{{ .Counter }}</td>
       <td>{{ .Duration }}</td>
-      <td>{{ .Speed | HumanSpeed }}</td>
-      <td>{{ .Speed | HumanTempo }}</td>
+      <td class="whitespace-nowrap">{{ .Speed | HumanSpeed }}</td>
+      <td class="whitespace-nowrap">{{ .Speed | HumanTempo }}</td>
     </tr>
     {{ end }}
   </tbody>
@@ -39,7 +39,8 @@
     <tr>
       <td colspan="2"></td>
       <td colspan="3">
-        {{ i18n "Last distance" }}: {{ $distance | HumanDistance }}
+        {{ i18n "Last distance" }}:
+        <span class="whitespace-nowrap">{{ $distance | HumanDistance }}</span>
       </td>
     </tr>
   </tfoot>

--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -30,74 +30,84 @@
     <tr>
       <td class="{{ IconFor `duration` }}"></td>
       <th>{{ i18n "Total duration" }}</th>
-      <td class="whitespace-nowrap">
+      <td class="whitespace-nowrap font-mono">
         {{ .Data.TotalDuration | HumanDuration }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `distance` }}"></td>
       <th>{{ i18n "Total distance" }}</th>
-      <td class="whitespace-nowrap">
+      <td class="whitespace-nowrap font-mono">
         {{ .Data.TotalDistance | HumanDistance }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `speed` }}"></td>
       <th>{{ i18n "Average speed" }}</th>
-      <td class="whitespace-nowrap">{{ .Data.AverageSpeed | HumanSpeed }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Data.AverageSpeed | HumanSpeed }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `speed` }}"></td>
       <th>{{ i18n "Average speed (no pause)" }}</th>
-      <td class="whitespace-nowrap">
+      <td class="whitespace-nowrap font-mono">
         {{ .Data.AverageSpeedNoPause | HumanSpeed }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `tempo` }}"></td>
       <th>{{ i18n "Average tempo" }}</th>
-      <td class="whitespace-nowrap">{{ .Data.AverageSpeed | HumanTempo }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Data.AverageSpeed | HumanTempo }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `tempo` }}"></td>
       <th>{{ i18n "Average tempo (no pause)" }}</th>
-      <td class="whitespace-nowrap">
+      <td class="whitespace-nowrap font-mono">
         {{ .Data.AverageSpeedNoPause | HumanTempo }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `max-speed` }}"></td>
       <th>{{ i18n "Max speed" }}</th>
-      <td class="whitespace-nowrap">{{ .Data.MaxSpeed | HumanSpeed }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Data.MaxSpeed | HumanSpeed }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `pause` }}"></td>
       <th>{{ i18n "Time paused" }}</th>
-      <td class="whitespace-nowrap">{{ .Data.PauseDuration }}</td>
+      <td class="whitespace-nowrap font-mono">{{ .Data.PauseDuration }}</td>
     </tr>
     <tr>
       <td class="{{ IconFor `elevation` }}"></td>
       <th>{{ i18n "Min elevation" }}</th>
-      <td class="whitespace-nowrap">
+      <td class="whitespace-nowrap font-mono">
         {{ .Data.MinElevation | HumanDistance }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `elevation` }}"></td>
       <th>{{ i18n "Max elevation" }}</th>
-      <td class="whitespace-nowrap">
+      <td class="whitespace-nowrap font-mono">
         {{ .Data.MaxElevation | HumanDistance }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `up` }}"></td>
       <th>{{ i18n "Total up" }}</th>
-      <td class="whitespace-nowrap">{{ .Data.TotalUp | HumanDistance }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Data.TotalUp | HumanDistance }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `down` }}"></td>
       <th>{{ i18n "Total down" }}</th>
-      <td class="whitespace-nowrap">{{ .Data.TotalDown | HumanDistance }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Data.TotalDown | HumanDistance }}
+      </td>
     </tr>
   </tbody>
 </table>

--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -30,62 +30,74 @@
     <tr>
       <td class="{{ IconFor `duration` }}"></td>
       <th>{{ i18n "Total duration" }}</th>
-      <td>{{ .Data.TotalDuration | HumanDuration }}</td>
+      <td class="whitespace-nowrap">
+        {{ .Data.TotalDuration | HumanDuration }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `distance` }}"></td>
       <th>{{ i18n "Total distance" }}</th>
-      <td>{{ .Data.TotalDistance | HumanDistance }}</td>
+      <td class="whitespace-nowrap">
+        {{ .Data.TotalDistance | HumanDistance }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `speed` }}"></td>
       <th>{{ i18n "Average speed" }}</th>
-      <td>{{ .Data.AverageSpeed | HumanSpeed }}</td>
+      <td class="whitespace-nowrap">{{ .Data.AverageSpeed | HumanSpeed }}</td>
     </tr>
     <tr>
       <td class="{{ IconFor `speed` }}"></td>
       <th>{{ i18n "Average speed (no pause)" }}</th>
-      <td>{{ .Data.AverageSpeedNoPause | HumanSpeed }}</td>
+      <td class="whitespace-nowrap">
+        {{ .Data.AverageSpeedNoPause | HumanSpeed }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `tempo` }}"></td>
       <th>{{ i18n "Average tempo" }}</th>
-      <td>{{ .Data.AverageSpeed | HumanTempo }}</td>
+      <td class="whitespace-nowrap">{{ .Data.AverageSpeed | HumanTempo }}</td>
     </tr>
     <tr>
       <td class="{{ IconFor `tempo` }}"></td>
       <th>{{ i18n "Average tempo (no pause)" }}</th>
-      <td>{{ .Data.AverageSpeedNoPause | HumanTempo }}</td>
+      <td class="whitespace-nowrap">
+        {{ .Data.AverageSpeedNoPause | HumanTempo }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `max-speed` }}"></td>
       <th>{{ i18n "Max speed" }}</th>
-      <td>{{ .Data.MaxSpeed | HumanSpeed }}</td>
+      <td class="whitespace-nowrap">{{ .Data.MaxSpeed | HumanSpeed }}</td>
     </tr>
     <tr>
       <td class="{{ IconFor `pause` }}"></td>
       <th>{{ i18n "Time paused" }}</th>
-      <td>{{ .Data.PauseDuration }}</td>
+      <td class="whitespace-nowrap">{{ .Data.PauseDuration }}</td>
     </tr>
     <tr>
       <td class="{{ IconFor `elevation` }}"></td>
       <th>{{ i18n "Min elevation" }}</th>
-      <td>{{ .Data.MinElevation | HumanDistance }}</td>
+      <td class="whitespace-nowrap">
+        {{ .Data.MinElevation | HumanDistance }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `elevation` }}"></td>
       <th>{{ i18n "Max elevation" }}</th>
-      <td>{{ .Data.MaxElevation | HumanDistance }}</td>
+      <td class="whitespace-nowrap">
+        {{ .Data.MaxElevation | HumanDistance }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `up` }}"></td>
       <th>{{ i18n "Total up" }}</th>
-      <td>{{ .Data.TotalUp | HumanDistance }}</td>
+      <td class="whitespace-nowrap">{{ .Data.TotalUp | HumanDistance }}</td>
     </tr>
     <tr>
       <td class="{{ IconFor `down` }}"></td>
       <th>{{ i18n "Total down" }}</th>
-      <td>{{ .Data.TotalDown | HumanDistance }}</td>
+      <td class="whitespace-nowrap">{{ .Data.TotalDown | HumanDistance }}</td>
     </tr>
   </tbody>
 </table>

--- a/views/partials/workout_item.html
+++ b/views/partials/workout_item.html
@@ -30,31 +30,31 @@
     </div>
     <div class="flex flex-wrap gap-2">
       <div
-        class="workout-tile-info {{ IconFor `distance` }}"
+        class="workout-tile-info {{ IconFor `distance` }} whitespace-nowrap"
         title="Total distance"
       >
         {{ .Data.TotalDistance | HumanDistance }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `duration` }}"
+        class="workout-tile-info {{ IconFor `duration` }} whitespace-nowrap"
         title="Total duration"
       >
         {{ .Data.TotalDuration | HumanDuration }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `speed` }}"
+        class="workout-tile-info {{ IconFor `speed` }} whitespace-nowrap"
         title="Average speed (no pause)"
       >
         {{ .Data.AverageSpeedNoPause | HumanSpeed }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `tempo` }}"
+        class="workout-tile-info {{ IconFor `tempo` }} whitespace-nowrap"
         title="Average tempo (no pause)"
       >
         {{ .Data.AverageSpeedNoPause | HumanTempo }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `max-speed` }}"
+        class="workout-tile-info {{ IconFor `max-speed` }} whitespace-nowrap"
         title="Max speed"
       >
         {{ .Data.MaxSpeed | HumanSpeed }}

--- a/views/partials/workout_item.html
+++ b/views/partials/workout_item.html
@@ -30,31 +30,31 @@
     </div>
     <div class="flex flex-wrap gap-2">
       <div
-        class="workout-tile-info {{ IconFor `distance` }} whitespace-nowrap"
+        class="workout-tile-info {{ IconFor `distance` }} whitespace-nowrap font-mono"
         title="Total distance"
       >
         {{ .Data.TotalDistance | HumanDistance }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `duration` }} whitespace-nowrap"
+        class="workout-tile-info {{ IconFor `duration` }} whitespace-nowrap font-mono"
         title="Total duration"
       >
         {{ .Data.TotalDuration | HumanDuration }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `speed` }} whitespace-nowrap"
+        class="workout-tile-info {{ IconFor `speed` }} whitespace-nowrap font-mono"
         title="Average speed (no pause)"
       >
         {{ .Data.AverageSpeedNoPause | HumanSpeed }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `tempo` }} whitespace-nowrap"
+        class="workout-tile-info {{ IconFor `tempo` }} whitespace-nowrap font-mono"
         title="Average tempo (no pause)"
       >
         {{ .Data.AverageSpeedNoPause | HumanTempo }}
       </div>
       <div
-        class="workout-tile-info {{ IconFor `max-speed` }} whitespace-nowrap"
+        class="workout-tile-info {{ IconFor `max-speed` }} whitespace-nowrap font-mono"
         title="Max speed"
       >
         {{ .Data.MaxSpeed | HumanSpeed }}

--- a/views/workouts/workouts_list.html
+++ b/views/workouts/workouts_list.html
@@ -60,30 +60,30 @@
             </td>
             <td
               sorttable_customkey="{{ .Data.TotalDistance }}"
-              class="whitespace-nowrap"
+              class="whitespace-nowrap font-mono"
             >
               {{ .Data.TotalDistance | HumanDistance }}
             </td>
             <td
-              class="hidden sm:table-cell whitespace-nowrap"
+              class="hidden sm:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.TotalDuration | NumericDuration }}"
             >
               {{ .Data.TotalDuration }}
             </td>
             <td
-              class="hidden 2xl:table-cell whitespace-nowrap"
+              class="hidden 2xl:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.AverageSpeedNoPause }}"
             >
               {{ .Data.AverageSpeedNoPause | HumanSpeed }}
             </td>
             <td
-              class="hidden 2xl:table-cell whitespace-nowrap"
+              class="hidden 2xl:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.AverageSpeedNoPause }}"
             >
               {{ .Data.AverageSpeedNoPause | HumanTempo }}
             </td>
             <td
-              class="hidden 2xl:table-cell whitespace-nowrap"
+              class="hidden 2xl:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.MaxSpeed }}"
             >
               {{ .Data.MaxSpeed | HumanSpeed }}

--- a/views/workouts/workouts_list.html
+++ b/views/workouts/workouts_list.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     {{ template "head" }}

--- a/views/workouts/workouts_list.html
+++ b/views/workouts/workouts_list.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     {{ template "head" }}
@@ -58,29 +58,32 @@
             <td class="hidden xl:table-cell">
               {{ template "snippet_location" .Data.Address }}
             </td>
-            <td sorttable_customkey="{{ .Data.TotalDistance }}">
+            <td
+              sorttable_customkey="{{ .Data.TotalDistance }}"
+              class="whitespace-nowrap"
+            >
               {{ .Data.TotalDistance | HumanDistance }}
             </td>
             <td
-              class="hidden sm:table-cell"
+              class="hidden sm:table-cell whitespace-nowrap"
               sorttable_customkey="{{ .Data.TotalDuration | NumericDuration }}"
             >
               {{ .Data.TotalDuration }}
             </td>
             <td
-              class="hidden 2xl:table-cell"
+              class="hidden 2xl:table-cell whitespace-nowrap"
               sorttable_customkey="{{ .Data.AverageSpeedNoPause }}"
             >
               {{ .Data.AverageSpeedNoPause | HumanSpeed }}
             </td>
             <td
-              class="hidden 2xl:table-cell"
+              class="hidden 2xl:table-cell whitespace-nowrap"
               sorttable_customkey="{{ .Data.AverageSpeedNoPause }}"
             >
               {{ .Data.AverageSpeedNoPause | HumanTempo }}
             </td>
             <td
-              class="hidden 2xl:table-cell"
+              class="hidden 2xl:table-cell whitespace-nowrap"
               sorttable_customkey="{{ .Data.MaxSpeed }}"
             >
               {{ .Data.MaxSpeed | HumanSpeed }}


### PR DESCRIPTION
This PR prevents statistics with units (such as `1:23 min/km`) from being wrapped over two lines. This looks much nicer imo.

Before:

<img width="325" alt="image" src="https://github.com/jovandeginste/workout-tracker/assets/181337/6c82a3b8-7f6c-4abf-a7c5-3d02d66d391e">

After:

<img width="344" alt="image" src="https://github.com/jovandeginste/workout-tracker/assets/181337/c764d9cb-750e-4814-9079-49ff950c2397">

I applied the class `whitespace-nowrap` to all places I could find, might have missed some though. 