### PR TITLE
Remove GPX when removing workout, and fix not null constraint

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -27,7 +27,7 @@ type Workout struct {
 
 	GPXData  []byte `gorm:"type:mediumtext"`
 	Filename string
-	Checksum []byte
+	Checksum []byte `gorm:"default:legacy"`
 }
 
 type GPXData struct {
@@ -160,7 +160,7 @@ func GetWorkout(db *gorm.DB, id int) (*Workout, error) {
 }
 
 func (w *Workout) Delete(db *gorm.DB) error {
-	return db.Unscoped().Delete(w).Error
+	return db.Unscoped().Select("GPX").Delete(w).Error
 }
 
 func (w *Workout) Create(db *gorm.DB) error {


### PR DESCRIPTION
When we remove a workout, we should clean up the associated GPX file; otherwise, you can not add it back later.

We also override the "NOT NULL" constraint by setting a different tag. This seems to be a weird workaround, but it's only for the time it needs to get removed entirely, anyway.

This should fix #33