### PR TITLE
Add (kind of) support for distance-less GPX and FIT

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -3,6 +3,7 @@ package database
 import (
 	"crypto/sha256"
 	"errors"
+	"log"
 	"strings"
 	"time"
 
@@ -167,6 +168,8 @@ func (w *Workout) Create(db *gorm.DB) error {
 	if w.Data == nil {
 		return ErrInvalidData
 	}
+
+	log.Printf("%#v\n", w.Data)
 
 	return db.Create(w).Error
 }

--- a/pkg/database/workouts_statistics.go
+++ b/pkg/database/workouts_statistics.go
@@ -86,6 +86,10 @@ func (w *Workout) StatisticsPerMinute() []StatisticsItem {
 }
 
 func (w *Workout) statisticsWithUnit(unit string) []StatisticsItem {
+	if len(w.Data.Points) == 0 {
+		return nil
+	}
+
 	var items []StatisticsItem
 
 	nextItem := StatisticsItem{

--- a/pkg/templatehelpers/template_funcs.go
+++ b/pkg/templatehelpers/template_funcs.go
@@ -41,6 +41,10 @@ func HumanSpeed(mps float64) string {
 }
 
 func HumanTempo(mps float64) string {
+	if mps == 0 {
+		return "0 min/m"
+	}
+
 	mpk := 1000000 / (mps * 60)
 	value, prefix := humanize.ComputeSI(mpk)
 

--- a/views/partials/workout_breakdown.html
+++ b/views/partials/workout_breakdown.html
@@ -10,7 +10,7 @@
     </tr>
   </thead>
   <tbody>
-    {{ $distance := 0 }} {{ range . }} {{ $distance = .Distance }}
+    {{ $distance := 0.0 }} {{ range . }} {{ $distance = .Distance }}
     <tr
       {{
       with


### PR DESCRIPTION
This will no longer crash when uploading workout files without any kind of distance. This may be useful to still get some duration out of it.

The resulting information is weird (for now) because of the many 0's.

Fixes #38