### PR TITLE
Add auto-import feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN go build \
 FROM alpine:latest
 
 RUN apk add --no-cache tzdata
-VOLUME /data
+VOLUME /data /imports
 WORKDIR /app
 COPY --from=backend /workout-tracker ./workout-tracker
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,5 @@ these sources:
   - importing fit files works, kinda: there seems to be an issue with the elevation
   - see https://github.com/tormoder/fit/issues/87
   - https://www.fitfileviewer.com/ gives the same elevation issue
-- add support for auto-import from a folder (per user)
 - see if htmx is worth using
   - first I need a use case

--- a/pkg/app/background.go
+++ b/pkg/app/background.go
@@ -1,0 +1,194 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jovandeginste/workout-tracker/pkg/database"
+)
+
+var (
+	ErrWorker          = errors.New("worker error")
+	ErrNothingImported = errors.New("nothing imported")
+)
+
+const (
+	FileAddDelay = -1 * time.Minute
+	WorkerDelay  = 1 * time.Minute
+)
+
+func (a *App) BackgroundWorker() {
+	l := a.logger.With("module", "worker")
+
+	for {
+		l.Info("Worker started...")
+
+		a.updateWorkout(l)
+		a.autoImports(l)
+
+		l.Info("Worker finished...")
+		time.Sleep(WorkerDelay)
+	}
+}
+
+func (a *App) autoImports(l *slog.Logger) {
+	var uID []int
+
+	q := a.db.Model(&database.User{}).Pluck("ID", &uID)
+	if err := q.Error; err != nil {
+		l.Error(ErrWorker.Error() + ": " + err.Error())
+	}
+
+	for _, i := range uID {
+		if err := a.autoImportForUser(l, i); err != nil {
+			l.Error(ErrWorker.Error() + ": " + err.Error())
+		}
+	}
+}
+
+func (a *App) autoImportForUser(l *slog.Logger, userID int) error {
+	u, err := database.GetUserByID(a.db, userID)
+	if err != nil {
+		return err
+	}
+
+	userLogger := l.With("user", u.Username)
+
+	ok, err := u.Profile.CanImportFromDirectory()
+	if err != nil {
+		return fmt.Errorf("could not use auto-import dir %v for user %v: %w", u.Profile.AutoImportDirectory, u.Username, err)
+	}
+
+	if !ok {
+		return nil
+	}
+
+	userLogger.Info("Importing from '" + u.Profile.AutoImportDirectory + "'")
+
+	// parse all files in the directory, non-recusive
+	files, err := filepath.Glob(filepath.Join(u.Profile.AutoImportDirectory, "*"))
+	if err != nil {
+		return err
+	}
+
+	for _, path := range files {
+		pathLogger := userLogger.With("path", path)
+
+		if err := a.importForUser(pathLogger, u, path); err != nil {
+			pathLogger.Error("Could not import: " + err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (a *App) importForUser(logger *slog.Logger, u *database.User, path string) error {
+	// Get file info for path
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if !fileCanBeImported(path, info) {
+		return nil
+	}
+
+	if importErr := a.importFile(logger, u, path); importErr != nil {
+		logger.Error("Could not import: " + importErr.Error())
+		return moveImportFile(logger, u.Profile.AutoImportDirectory, path, "failed")
+	}
+
+	return moveImportFile(logger, u.Profile.AutoImportDirectory, path, "done")
+}
+
+func moveImportFile(logger *slog.Logger, dir, path, statusDir string) error {
+	destDir := filepath.Join(dir, statusDir)
+
+	logger.Info("Moving to '" + destDir + "'")
+
+	// If destDir does not exist, create it
+	if _, err := os.Stat(destDir); errors.Is(err, os.ErrNotExist) {
+		if err := os.Mkdir(destDir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Rename(path, filepath.Join(destDir, filepath.Base(path))); err != nil {
+		return err
+	}
+
+	logger.Info("Moved to '" + destDir + "'")
+
+	return nil
+}
+
+func (a *App) importFile(logger *slog.Logger, u *database.User, path string) error {
+	logger.Info("Importing path")
+
+	dat, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	w, err := u.AddWorkout(a.db, database.WorkoutTypeAutoDetect, "", path, dat)
+	if err != nil {
+		return err
+	}
+
+	if w == nil {
+		return ErrNothingImported
+	}
+
+	logger.Info("Finished import.")
+
+	return nil
+}
+
+func fileCanBeImported(p string, i os.FileInfo) bool {
+	if i.IsDir() {
+		return false
+	}
+
+	// If file was changed within the last minute, don't import it
+	if i.ModTime().After(time.Now().Add(FileAddDelay)) {
+		return false
+	}
+
+	for _, e := range []string{".gpx", ".fit"} {
+		if filepath.Ext(p) == e {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (a *App) updateWorkout(l *slog.Logger) {
+	var wID []int
+
+	q := a.db.Model(&database.Workout{}).Where(&database.Workout{Dirty: true}).Limit(1000).Pluck("ID", &wID)
+	if err := q.Error; err != nil {
+		l.Error("Worker error: " + err.Error())
+	}
+
+	for _, i := range wID {
+		l.Info(fmt.Sprintf("Updating workout %d", i))
+
+		if err := a.UpdateWorkout(i); err != nil {
+			l.Error("Worker error: " + err.Error())
+		}
+	}
+}
+
+func (a *App) UpdateWorkout(i int) error {
+	w, err := database.GetWorkoutWithGPX(a.db, i)
+	if err != nil {
+		return err
+	}
+
+	return w.UpdateData(a.db)
+}

--- a/pkg/app/self_handlers.go
+++ b/pkg/app/self_handlers.go
@@ -24,6 +24,7 @@ func (a *App) userProfileUpdateHandler(c echo.Context) error {
 	u.Profile.Language = p.Language
 	u.Profile.TotalsShow = p.TotalsShow
 	u.Profile.Timezone = p.Timezone
+	u.Profile.AutoImportDirectory = p.AutoImportDirectory
 
 	if err := u.Profile.Save(a.db); err != nil {
 		return a.redirectWithError(c, a.echo.Reverse("user-profile"), err)

--- a/pkg/database/profile.go
+++ b/pkg/database/profile.go
@@ -1,20 +1,45 @@
 package database
 
 import (
+	"fmt"
+	"os"
+
 	"gorm.io/gorm"
 )
 
 type Profile struct {
 	gorm.Model
-	UserID     uint
-	APIActive  bool        `form:"api_active"`
-	Language   string      `form:"language"`
-	TotalsShow WorkoutType `form:"totals_show"`
-	Timezone   string      `form:"timezone"`
+	UserID              uint
+	APIActive           bool        `form:"api_active"`
+	Language            string      `form:"language"`
+	TotalsShow          WorkoutType `form:"totals_show"`
+	Timezone            string      `form:"timezone"`
+	AutoImportDirectory string      `form:"auto_import_directory"`
 
 	User *User `gorm:"foreignKey:UserID"`
 }
 
 func (p *Profile) Save(db *gorm.DB) error {
 	return db.Save(p).Error
+}
+
+func (p *Profile) CanImportFromDirectory() (bool, error) {
+	if p == nil {
+		return false, nil
+	}
+
+	if p.AutoImportDirectory == "" {
+		return false, nil
+	}
+
+	info, err := os.Stat(p.AutoImportDirectory)
+	if err != nil {
+		return false, err
+	}
+
+	if !info.IsDir() {
+		return false, fmt.Errorf("%v is not a directory", p.AutoImportDirectory)
+	}
+
+	return true, nil
 }

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -72,7 +72,7 @@ func GetUsers(db *gorm.DB) ([]User, error) {
 func GetUserByID(db *gorm.DB, userID int) (*User, error) {
 	var u User
 
-	if err := db.First(&u, userID).Error; err != nil {
+	if err := db.Preload("Profile").First(&u, userID).Error; err != nil {
 		return nil, db.Error
 	}
 

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -3,7 +3,6 @@ package database
 import (
 	"crypto/sha256"
 	"errors"
-	"log"
 	"strings"
 	"time"
 
@@ -168,8 +167,6 @@ func (w *Workout) Create(db *gorm.DB) error {
 	if w.Data == nil {
 		return ErrInvalidData
 	}
-
-	log.Printf("%#v\n", w.Data)
 
 	return db.Create(w).Error
 }

--- a/views/user/user_profile.html
+++ b/views/user/user_profile.html
@@ -54,6 +54,23 @@
                 </td>
               </tr>
               <tr>
+                <th>
+                  <label for="auto_import_directory"
+                    >{{ i18n "Auto import directory" }}</label
+                  >
+                </th>
+                <td>
+                  <input
+                    type="text"
+                    id="auto_import_directory"
+                    name="auto_import_directory"
+                    size="40"
+                    value="{{ CurrentUser.Profile.AutoImportDirectory }}"
+                    placeholder="/imports/{{ CurrentUser.Username }}/"
+                  />
+                </td>
+              </tr>
+              <tr>
                 <td></td>
                 <td>
                   <button type="submit">{{ i18n "Update profile" }}</button>


### PR DESCRIPTION
Each user can configure a folder from which to automatically import workout files. This folder is then checked every minute, and each file older than one minute is added.

When this process fails, the file is moved to the "failed" subfolder; otherwise the file is added to the "done" subfolder. The subfolders are created when needed.

Fixes #40