### PR TITLE
Remove top-level user profile language and totals show from templates

### DIFF
--- a/pkg/app/data.go
+++ b/pkg/app/data.go
@@ -70,8 +70,6 @@ func (a *App) addUserInfo(data map[string]interface{}, c echo.Context) {
 	}
 
 	data["currentUser"] = u
-	data["userProfileLanguage"] = u.Profile.Language
-	data["userProfileTotalsShow"] = u.Profile.TotalsShow
 }
 
 func (a *App) addWorkouts(u *database.User, data map[string]interface{}) error {

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -49,8 +49,9 @@
   </div>
   {{ end }} {{ else }}
   <div class="sm:grow flex flex-wrap justify-end sm:justify-start"></div>
-  {{ end }} {{ if or (eq .userProfileLanguage nil) (eq .userProfileLanguage "")
-  (eq .userProfileLanguage "browser") }}
+  {{ end }} {{ if or (eq CurrentUser nil) (eq CurrentUser.Profile.Language nil)
+  (eq CurrentUser.Profile.Language "") (eq CurrentUser.Profile.Language
+  "browser") }}
   <div
     class="flex flex-wrap sm:min-w-[400px] justify-end mt-3 sm:mt-0 pt-3 sm:pt-0 border-neutral-500 border-t-2 sm:border-t-0"
   >

--- a/views/user/user_profile.html
+++ b/views/user/user_profile.html
@@ -67,8 +67,8 @@
                   >
                 </th>
                 <td>
-                  {{ template "user_profile_totals_show" .userProfileTotalsShow
-                  }}
+                  {{ template "user_profile_totals_show"
+                  CurrentUser.Profile.TotalsShow }}
                 </td>
               </tr>
               <tr>
@@ -82,7 +82,8 @@
                   <label for="language">{{ i18n "Language" }}</label>
                 </th>
                 <td>
-                  {{ template "user_profile_language" .userProfileLanguage }}
+                  {{ template "user_profile_language"
+                  CurrentUser.Profile.Language }}
                 </td>
               </tr>
               <tr>

--- a/views/user/user_show.html
+++ b/views/user/user_show.html
@@ -10,8 +10,8 @@
         {{ i18n "Dashboard for %s" .user.Name }}
       </h2>
 
-      {{ with (index .UserStatistics .userProfileTotalsShow.String) }} {{
-      template "stats_records_total" .Total }} {{ end }}
+      {{ with (index .UserStatistics CurrentUser.Profile.TotalsShow.String) }}
+      {{ template "stats_records_total" .Total }} {{ end }}
 
       <div class="lg:flex lg:flex-wrap [&>*]:basis-1/2">
         <div>


### PR DESCRIPTION
Removed top-level `userProfileLanguage` and `userProfileTotalsShow` values in templates, making them dependent on the current user's data instead. This change reduces the number of attributes that are added at the top level.