### PR TITLE
Allow API access via JWT authentication

### DIFF
--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -96,14 +96,9 @@ func (a *App) ValidateAdminMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
-func (a *App) ValidateUserMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(ctx echo.Context) error {
-		if err := a.setUser(ctx); err != nil {
-			log.Warn(err.Error())
-			return ctx.Redirect(http.StatusFound, a.echo.Reverse("user-signout"))
-		}
-
-		return next(ctx)
+func (a *App) ValidateUserMiddleware(ctx echo.Context) {
+	if err := a.setUser(ctx); err != nil {
+		log.Warn(err.Error())
 	}
 }
 
@@ -117,8 +112,8 @@ func (a *App) secureRoutes(e *echo.Group) *echo.Group {
 			log.Warn(err.Error())
 			return c.Redirect(http.StatusFound, a.echo.Reverse("user-signout"))
 		},
+		SuccessHandler: a.ValidateUserMiddleware,
 	}))
-	secureGroup.Use(a.ValidateUserMiddleware)
 
 	secureGroup.GET("/", a.dashboardHandler).Name = "dashboard"
 	secureGroup.GET("/statistics", a.statisticsHandler).Name = "statistics"

--- a/pkg/database/profile.go
+++ b/pkg/database/profile.go
@@ -16,7 +16,7 @@ type Profile struct {
 	Timezone            string      `form:"timezone"`
 	AutoImportDirectory string      `form:"auto_import_directory"`
 
-	User *User `gorm:"foreignKey:UserID"`
+	User *User `gorm:"foreignKey:UserID" json:"-"`
 }
 
 func (p *Profile) Save(db *gorm.DB) error {

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -36,7 +36,7 @@ type User struct {
 	Admin    bool   `form:"admin"`
 
 	Profile  Profile
-	Workouts []Workout
+	Workouts []Workout `json:"-"`
 }
 
 func (u *User) Timezone() *time.Location {


### PR DESCRIPTION
When we want to use the API from the web interface (eg. to update statistics), we will authenticate using the JWT token instead of the API key. This change should allow this.