### PR TITLE
Use the HumanDuration filter to properly print durations

### DIFF
--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -79,7 +79,9 @@
     <tr>
       <td class="{{ IconFor `pause` }}"></td>
       <th>{{ i18n "Time paused" }}</th>
-      <td class="whitespace-nowrap font-mono">{{ .Data.PauseDuration }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Data.PauseDuration | HumanDuration }}
+      </td>
     </tr>
     <tr>
       <td class="{{ IconFor `elevation` }}"></td>

--- a/views/workouts/workouts_list.html
+++ b/views/workouts/workouts_list.html
@@ -68,7 +68,7 @@
               class="hidden sm:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.TotalDuration | NumericDuration }}"
             >
-              {{ .Data.TotalDuration }}
+              {{ .Data.TotalDuration | HumanDuration }}
             </td>
             <td
               class="hidden 2xl:table-cell whitespace-nowrap font-mono"


### PR DESCRIPTION
Some places lacked the HumanDuration filter, which meant the values shown were not consistent and sometimes weird, like showing nanoseconds.

Fixes #66