### PR TITLE
Add per-user setting to disable social sharing buttons

### DIFF
--- a/pkg/app/self_handlers.go
+++ b/pkg/app/self_handlers.go
@@ -20,11 +20,13 @@ func (a *App) userProfileUpdateHandler(c echo.Context) error {
 		return a.redirectWithError(c, a.echo.Reverse("user-profile"), err)
 	}
 
+	u.Profile.User = u
 	u.Profile.APIActive = p.APIActive
 	u.Profile.Language = p.Language
 	u.Profile.TotalsShow = p.TotalsShow
 	u.Profile.Timezone = p.Timezone
 	u.Profile.AutoImportDirectory = p.AutoImportDirectory
+	u.Profile.SocialsDisabled = p.SocialsDisabled
 
 	if err := u.Profile.Save(a.db); err != nil {
 		return a.redirectWithError(c, a.echo.Reverse("user-profile"), err)

--- a/pkg/database/profile.go
+++ b/pkg/database/profile.go
@@ -15,6 +15,7 @@ type Profile struct {
 	TotalsShow          WorkoutType `form:"totals_show"`
 	Timezone            string      `form:"timezone"`
 	AutoImportDirectory string      `form:"auto_import_directory"`
+	SocialsDisabled     bool        `form:"socials_disabled"`
 
 	User *User `gorm:"foreignKey:UserID" json:"-"`
 }

--- a/views/user/user_profile.html
+++ b/views/user/user_profile.html
@@ -104,6 +104,25 @@
                 </td>
               </tr>
               <tr>
+                <th>
+                  <label for="socials_disabled"
+                    >{{ i18n "Disable social sharing buttons" }}</label
+                  >
+                </th>
+                <td>
+                  <input
+                    type="checkbox"
+                    id="socials_disabled"
+                    name="socials_disabled"
+                    value="true"
+                    {{
+                    BoolToCheckbox
+                    CurrentUser.Profile.SocialsDisabled
+                    }}
+                  />
+                </td>
+              </tr>
+              <tr>
                 <td></td>
                 <td>
                   <button type="submit">{{ i18n "Update profile" }}</button>

--- a/views/workouts/workouts_show.html
+++ b/views/workouts/workouts_show.html
@@ -52,8 +52,9 @@
               </script>
               <script src="{{ RouteFor `assets` }}/map.js"></script>
             </div>
-            {{ if not $.SocialsDisabled }} {{ template "workout_social" .}} {{
-            end }}
+            {{ if and (not $.SocialsDisabled) (not
+            CurrentUser.Profile.SocialsDisabled) }} {{ template "workout_social"
+            .}} {{ end }}
           </div>
         </div>
         <div class="basis-1/4">


### PR DESCRIPTION
When the setting is disabled system wide, this will take precedence over the per-user setting.

We also update the user id inside the profile struct, in case the user had no profile yet. This also fixes #61 for existing setups.