### PR TITLE
Remove redundant workout statistics from workouts handlers and templates

### DIFF
--- a/pkg/app/workouts_handlers.go
+++ b/pkg/app/workouts_handlers.go
@@ -35,8 +35,6 @@ func (a *App) workoutsShowHandler(c echo.Context) error {
 	}
 
 	data["workout"] = w
-	data["workoutStatisticsPerKM"] = w.StatisticsPerKilometer()
-	data["workoutStatisticsPerMin"] = w.StatisticsPerMinute()
 
 	return c.Render(http.StatusOK, "workouts_show.html", data)
 }
@@ -128,8 +126,6 @@ func (a *App) workoutsEditHandler(c echo.Context) error {
 	}
 
 	data["workout"] = workout
-	data["workoutStatisticsPerKM"] = workout.StatisticsPerKilometer()
-	data["workoutStatisticsPerMin"] = workout.StatisticsPerMinute()
 
 	return c.Render(http.StatusOK, "workouts_edit.html", data)
 }

--- a/views/workouts/workouts_edit.html
+++ b/views/workouts/workouts_edit.html
@@ -79,7 +79,7 @@
         </div>
         <div class="basis-1/4">
           <div class="inner-form">
-            {{ template "workout_breakdown" $.workoutStatisticsPerKM }}
+            {{ template "workout_breakdown" .StatisticsPerKilometer }}
           </div>
         </div>
       </div>

--- a/views/workouts/workouts_show.html
+++ b/views/workouts/workouts_show.html
@@ -62,7 +62,7 @@
         </div>
         <div class="basis-1/4">
           <div class="inner-form">
-            {{ template "workout_breakdown" $.workoutStatisticsPerKM }}
+            {{ template "workout_breakdown" .StatisticsPerKilometer }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Removed redundant workout statistics from workouts handlers and templates to improve code readability and maintainability.