### PR TITLE
Update Human* functions to return values without units

### DIFF
--- a/pkg/app/templates.go
+++ b/pkg/app/templates.go
@@ -40,10 +40,10 @@ func (t *Template) Render(w io.Writer, name string, data interface{}, ctx echo.C
 		"LocalTime":    func(t time.Time) time.Time { return t.In(u.Timezone()) },
 		"LocalDate":    func(t time.Time) string { return t.In(u.Timezone()).Format("2006-01-02 15:04") },
 
-		"HumanElevation": templatehelpers.HumanElevationFor(u.PreferredUnits().Elevation),
-		"HumanDistance":  templatehelpers.HumanDistanceFor(u.PreferredUnits().Distance),
-		"HumanSpeed":     templatehelpers.HumanSpeedFor(u.PreferredUnits().Speed),
-		"HumanTempo":     templatehelpers.HumanTempoFor(u.PreferredUnits().Distance),
+		"HumanElevation": templatehelpers.HumanElevationFor(u.PreferredUnits().Elevation()),
+		"HumanDistance":  templatehelpers.HumanDistanceFor(u.PreferredUnits().Distance()),
+		"HumanSpeed":     templatehelpers.HumanSpeedFor(u.PreferredUnits().Speed()),
+		"HumanTempo":     templatehelpers.HumanTempoFor(u.PreferredUnits().Distance()),
 	})
 
 	return r.ExecuteTemplate(w, name, data)

--- a/pkg/database/profile.go
+++ b/pkg/database/profile.go
@@ -23,10 +23,40 @@ type Profile struct {
 }
 
 type UserPreferredUnits struct {
-	Speed     string `form:"speed" `
-	Distance  string `form:"distance"`
-	Duration  string `form:"duration"`
-	Elevation string `form:"elevation"`
+	SpeedRaw     string `form:"speed" json:"speed"`
+	DistanceRaw  string `form:"distance" json:"distance"`
+	ElevationRaw string `form:"elevation" json:"elevation"`
+}
+
+func (u UserPreferredUnits) Tempo() string {
+	return "min/" + u.Distance()
+}
+
+func (u UserPreferredUnits) Elevation() string {
+	switch u.ElevationRaw {
+	case "feet":
+		return "feet"
+	default:
+		return "m"
+	}
+}
+
+func (u UserPreferredUnits) Distance() string {
+	switch u.DistanceRaw {
+	case "mi":
+		return "mi"
+	default:
+		return "km"
+	}
+}
+
+func (u UserPreferredUnits) Speed() string {
+	switch u.SpeedRaw {
+	case "mph":
+		return "mph"
+	default:
+		return "km/h"
+	}
 }
 
 func (p *Profile) Save(db *gorm.DB) error {

--- a/pkg/templatehelpers/imperial.go
+++ b/pkg/templatehelpers/imperial.go
@@ -11,7 +11,7 @@ const (
 )
 
 func HumanDistanceMile(d float64) string {
-	return fmt.Sprintf("%.2f mi", milesPerKM*d/1000)
+	return fmt.Sprintf("%.2f", milesPerKM*d/1000)
 }
 
 func HumanSpeedMilePH(mps float64) string {
@@ -21,7 +21,7 @@ func HumanSpeedMilePH(mps float64) string {
 
 	kmph := 3.6 * mps
 
-	return fmt.Sprintf("%.2f mi/h", milesPerKM*kmph)
+	return fmt.Sprintf("%.2f", milesPerKM*kmph)
 }
 
 func HumanTempoMile(mps float64) string {
@@ -34,9 +34,9 @@ func HumanTempoMile(mps float64) string {
 	wholeMinutes := math.Floor(mpm)
 	seconds := (mpm - wholeMinutes) * 60
 
-	return fmt.Sprintf("%d:%02d min/mi", int(wholeMinutes), int(seconds))
+	return fmt.Sprintf("%d:%02d", int(wholeMinutes), int(seconds))
 }
 
 func HumanElevationFt(m float64) string {
-	return fmt.Sprintf("%.2f ft", feetPerMeter*m)
+	return fmt.Sprintf("%.2f", feetPerMeter*m)
 }

--- a/pkg/templatehelpers/metric.go
+++ b/pkg/templatehelpers/metric.go
@@ -6,7 +6,7 @@ import (
 )
 
 func HumanDistanceKM(d float64) string {
-	return fmt.Sprintf("%.2f km", d/1000)
+	return fmt.Sprintf("%.2f", d/1000)
 }
 
 func HumanSpeedKPH(mps float64) string {
@@ -16,7 +16,7 @@ func HumanSpeedKPH(mps float64) string {
 
 	kmph := 3.6 * mps
 
-	return fmt.Sprintf("%.2f km/h", kmph)
+	return fmt.Sprintf("%.2f", kmph)
 }
 
 func HumanTempoKM(mps float64) string {
@@ -29,9 +29,9 @@ func HumanTempoKM(mps float64) string {
 	wholeMinutes := math.Floor(mpk)
 	seconds := (mpk - wholeMinutes) * 60
 
-	return fmt.Sprintf("%d:%02d min/km", int(wholeMinutes), int(seconds))
+	return fmt.Sprintf("%d:%02d", int(wholeMinutes), int(seconds))
 }
 
 func HumanElevationM(m float64) string {
-	return fmt.Sprintf("%.2f m", m)
+	return fmt.Sprintf("%.2f", m)
 }

--- a/pkg/templatehelpers/template_funcs.go
+++ b/pkg/templatehelpers/template_funcs.go
@@ -86,13 +86,15 @@ type DecoratedAttribute struct {
 	Icon  string
 	Name  string
 	Value interface{}
+	Unit  string
 }
 
-func BuildDecoratedAttribute(icon, name string, value interface{}) DecoratedAttribute {
+func BuildDecoratedAttribute(icon, name string, value interface{}, unit string) DecoratedAttribute {
 	return DecoratedAttribute{
 		Icon:  icon,
 		Name:  name,
 		Value: value,
+		Unit:  unit,
 	}
 }
 

--- a/pkg/templatehelpers/template_funcs_test.go
+++ b/pkg/templatehelpers/template_funcs_test.go
@@ -19,28 +19,28 @@ func TestCountryCodeToFlag(t *testing.T) {
 }
 
 func TestHumanDistanceKM(t *testing.T) {
-	assert.Equal(t, "0.00 km", HumanDistanceKM(1.23))
-	assert.Equal(t, "1.23 km", HumanDistanceKM(1234))
-	assert.Equal(t, "1234.57 km", HumanDistanceKM(1234567))
+	assert.Equal(t, "0.00", HumanDistanceKM(1.23))
+	assert.Equal(t, "1.23", HumanDistanceKM(1234))
+	assert.Equal(t, "1234.57", HumanDistanceKM(1234567))
 }
 
 func TestHumanDistance(t *testing.T) {
-	assert.Equal(t, "0.00 km", HumanDistanceKM(1.23))
-	assert.Equal(t, "1.23 km", HumanDistanceKM(1234))
-	assert.Equal(t, "1234.57 km", HumanDistanceKM(1234567))
+	assert.Equal(t, "0.00", HumanDistanceKM(1.23))
+	assert.Equal(t, "1.23", HumanDistanceKM(1234))
+	assert.Equal(t, "1234.57", HumanDistanceKM(1234567))
 }
 
 func TestHumanSpeedKPH(t *testing.T) {
-	assert.Equal(t, "4.43 km/h", HumanSpeedKPH(1.23))
-	assert.Equal(t, "10.01 km/h", HumanSpeedKPH(2.78))
-	assert.Equal(t, "17.96 km/h", HumanSpeedKPH(4.99))
+	assert.Equal(t, "4.43", HumanSpeedKPH(1.23))
+	assert.Equal(t, "10.01", HumanSpeedKPH(2.78))
+	assert.Equal(t, "17.96", HumanSpeedKPH(4.99))
 }
 
 func TestHumanTempoKM(t *testing.T) {
-	assert.Equal(t, "13:33 min/km", HumanTempoKM(1.23))
-	assert.Equal(t, "5:59 min/km", HumanTempoKM(2.78))
-	assert.Equal(t, "3:20 min/km", HumanTempoKM(4.99))
-	assert.Equal(t, "5:01 min/km", HumanTempoKM(3.32))
+	assert.Equal(t, "13:33", HumanTempoKM(1.23))
+	assert.Equal(t, "5:59", HumanTempoKM(2.78))
+	assert.Equal(t, "3:20", HumanTempoKM(4.99))
+	assert.Equal(t, "5:01", HumanTempoKM(3.32))
 }
 
 func TestBoolToHTML(t *testing.T) {
@@ -54,10 +54,11 @@ func TestBoolToCheckbox(t *testing.T) {
 }
 
 func TestBuildDecoratedAttribute(t *testing.T) {
-	r := BuildDecoratedAttribute("the-icon", "the-name", "the-value")
+	r := BuildDecoratedAttribute("the-icon", "the-name", "the-value", "the-unit")
 
 	assert.NotNil(t, r)
 	assert.Equal(t, "the-icon", r.Icon)
 	assert.Equal(t, "the-name", r.Name)
 	assert.Equal(t, "the-value", r.Value)
+	assert.Equal(t, "the-unit", r.Unit)
 }

--- a/views/partials/statistic_tile.html
+++ b/views/partials/statistic_tile.html
@@ -9,7 +9,7 @@
         <div
           class="text-xl md:text-3xl text-right font-mono md:h-8 overflow-hidden"
         >
-          {{ .Value }}
+          {{ .Value }} {{ .Unit }}
         </div>
         <div class="text-neutral-600 dark:text-neutral-400 text-sm text-right">
           {{ .Name }}

--- a/views/partials/stats_records_distance.html
+++ b/views/partials/stats_records_distance.html
@@ -25,7 +25,9 @@
       <th>
         <span class="{{ IconFor `speed` }}">{{ i18n "Average speed" }}</span>
       </th>
-      <td class="font-mono whitespace-nowrap">{{ .Value | HumanSpeed }}</td>
+      <td class="font-mono whitespace-nowrap">
+        {{ .Value | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
+      </td>
       <td>{{ template "stats_record_distance_date" . }}</td>
     </tr>
     {{ end }} {{ with .AverageSpeedNoPause }}
@@ -35,7 +37,9 @@
           >{{ i18n "Average speed (no pause)" }}</span
         >
       </th>
-      <td class="font-mono whitespace-nowrap">{{ .Value | HumanSpeed }}</td>
+      <td class="font-mono whitespace-nowrap">
+        {{ .Value | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
+      </td>
       <td>{{ template "stats_record_distance_date" . }}</td>
     </tr>
     {{ end }} {{ with .MaxSpeed }}
@@ -43,7 +47,9 @@
       <th>
         <span class="{{ IconFor `max-speed` }}">{{ i18n "Max speed" }}</span>
       </th>
-      <td class="font-mono whitespace-nowrap">{{ .Value | HumanSpeed }}</td>
+      <td class="font-mono whitespace-nowrap">
+        {{ .Value | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
+      </td>
       <td>{{ template "stats_record_distance_date" . }}</td>
     </tr>
     {{ end }} {{ with .Distance }}
@@ -53,7 +59,9 @@
           >{{ i18n "Total distance" }}</span
         >
       </th>
-      <td class="font-mono whitespace-nowrap">{{ .Value | HumanDistance }}</td>
+      <td class="font-mono whitespace-nowrap">
+        {{ .Value | HumanDistance }} {{ CurrentUser.PreferredUnits.Distance }}
+      </td>
       <td>{{ template "stats_record_distance_date" . }}</td>
     </tr>
     {{ end }} {{ with .TotalUp }}
@@ -61,7 +69,9 @@
       <th>
         <span class="{{ IconFor `up` }}">{{ i18n "Total up" }}</span>
       </th>
-      <td class="font-mono whitespace-nowrap">{{ .Value | HumanElevation }}</td>
+      <td class="font-mono whitespace-nowrap">
+        {{ .Value | HumanElevation }} {{ CurrentUser.PreferredUnits.Elevation }}
+      </td>
       <td>{{ template "stats_record_distance_date" . }}</td>
     </tr>
     {{ end }} {{ with .Duration }}

--- a/views/partials/stats_records_totals.html
+++ b/views/partials/stats_records_totals.html
@@ -2,10 +2,11 @@
 <div class="md:flex md:flex-wrap">
   {{ $di := i18n "distance" }} {{ $w := i18n "workouts"}} {{ $u := i18n "up" }}
   {{ $du := i18n "duration" }} {{ template "statistic_tile"
-  (BuildDecoratedAttribute "workout" $w .Workouts) }} {{ template
+  (BuildDecoratedAttribute "workout" $w .Workouts "") }} {{ template
   "statistic_tile" (BuildDecoratedAttribute "distance" $di (.Distance |
-  HumanDistance )) }} {{ template "statistic_tile" (BuildDecoratedAttribute "up"
-  $u (.Up | HumanElevation)) }} {{ template "statistic_tile"
-  (BuildDecoratedAttribute "duration" $du (.Duration | HumanDuration)) }}
+  HumanDistance ) CurrentUser.PreferredUnits.Distance) }} {{ template
+  "statistic_tile" (BuildDecoratedAttribute "up" $u (.Up | HumanElevation)
+  CurrentUser.PreferredUnits.Elevation) }} {{ template "statistic_tile"
+  (BuildDecoratedAttribute "duration" $du (.Duration | HumanDuration) "") }}
 </div>
 {{ end }} {{ end }}

--- a/views/partials/workout_breakdown.html
+++ b/views/partials/workout_breakdown.html
@@ -30,10 +30,17 @@
         <span class="text-green-500 {{ IconFor `best` }}"></span>{{ end }}
       </td>
       <td class="text-center">{{ .Counter }}</td>
-      <td>{{ .TotalDistance | HumanDistance }}</td>
+      <td>
+        {{ .TotalDistance | HumanDistance }} {{
+        CurrentUser.PreferredUnits.Distance }}
+      </td>
       <td>{{ .Duration | HumanDuration }}</td>
-      <td class="whitespace-nowrap font-mono">{{ .Speed | HumanSpeed }}</td>
-      <td class="whitespace-nowrap font-mono">{{ .Speed | HumanTempo }}</td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Speed | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
+      </td>
+      <td class="whitespace-nowrap font-mono">
+        {{ .Speed | HumanTempo }} {{ CurrentUser.PreferredUnits.Tempo }}
+      </td>
     </tr>
     {{ end }}
   </tbody>

--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -38,42 +38,47 @@
       <td class="{{ IconFor `distance` }}"></td>
       <th>{{ i18n "Total distance" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.TotalDistance | HumanDistance }}
+        {{ .Data.TotalDistance | HumanDistance }} {{
+        CurrentUser.PreferredUnits.Distance }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `speed` }}"></td>
       <th>{{ i18n "Average speed" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.AverageSpeed | HumanSpeed }}
+        {{ .Data.AverageSpeed | HumanSpeed }} {{
+        CurrentUser.PreferredUnits.Speed }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `speed` }}"></td>
       <th>{{ i18n "Average speed (no pause)" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.AverageSpeedNoPause | HumanSpeed }}
+        {{ .Data.AverageSpeedNoPause | HumanSpeed }} {{
+        CurrentUser.PreferredUnits.Speed }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `tempo` }}"></td>
       <th>{{ i18n "Average tempo" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.AverageSpeed | HumanTempo }}
+        {{ .Data.AverageSpeed | HumanTempo }} {{
+        CurrentUser.PreferredUnits.Tempo }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `tempo` }}"></td>
       <th>{{ i18n "Average tempo (no pause)" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.AverageSpeedNoPause | HumanTempo }}
+        {{ .Data.AverageSpeedNoPause | HumanTempo }} {{
+        CurrentUser.PreferredUnits.Tempo }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `max-speed` }}"></td>
       <th>{{ i18n "Max speed" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.MaxSpeed | HumanSpeed }}
+        {{ .Data.MaxSpeed | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
       </td>
     </tr>
     <tr>
@@ -87,28 +92,32 @@
       <td class="{{ IconFor `elevation` }}"></td>
       <th>{{ i18n "Min elevation" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.MinElevation | HumanElevation }}
+        {{ .Data.MinElevation | HumanElevation }} {{
+        CurrentUser.PreferredUnits.Elevation }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `elevation` }}"></td>
       <th>{{ i18n "Max elevation" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.MaxElevation | HumanElevation }}
+        {{ .Data.MaxElevation | HumanElevation }} {{
+        CurrentUser.PreferredUnits.Elevation }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `up` }}"></td>
       <th>{{ i18n "Total up" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.TotalUp | HumanElevation }}
+        {{ .Data.TotalUp | HumanElevation }} {{
+        CurrentUser.PreferredUnits.Elevation }}
       </td>
     </tr>
     <tr>
       <td class="{{ IconFor `down` }}"></td>
       <th>{{ i18n "Total down" }}</th>
       <td class="whitespace-nowrap font-mono">
-        {{ .Data.TotalDown | HumanElevation }}
+        {{ .Data.TotalDown | HumanElevation }} {{
+        CurrentUser.PreferredUnits.Elevation }}
       </td>
     </tr>
   </tbody>

--- a/views/partials/workout_item.html
+++ b/views/partials/workout_item.html
@@ -33,7 +33,8 @@
         class="workout-tile-info {{ IconFor `distance` }} whitespace-nowrap font-mono"
         title="Total distance"
       >
-        {{ .Data.TotalDistance | HumanDistance }}
+        {{ .Data.TotalDistance | HumanDistance }} {{
+        CurrentUser.PreferredUnits.Distance }}
       </div>
       <div
         class="workout-tile-info {{ IconFor `duration` }} whitespace-nowrap font-mono"
@@ -45,19 +46,21 @@
         class="workout-tile-info {{ IconFor `speed` }} whitespace-nowrap font-mono"
         title="Average speed (no pause)"
       >
-        {{ .Data.AverageSpeedNoPause | HumanSpeed }}
+        {{ .Data.AverageSpeedNoPause | HumanSpeed }} {{
+        CurrentUser.PreferredUnits.Speed }}
       </div>
       <div
         class="workout-tile-info {{ IconFor `tempo` }} whitespace-nowrap font-mono"
         title="Average tempo (no pause)"
       >
-        {{ .Data.AverageSpeedNoPause | HumanTempo }}
+        {{ .Data.AverageSpeedNoPause | HumanTempo }} {{
+        CurrentUser.PreferredUnits.Tempo }}
       </div>
       <div
         class="workout-tile-info {{ IconFor `max-speed` }} whitespace-nowrap font-mono"
         title="Max speed"
       >
-        {{ .Data.MaxSpeed | HumanSpeed }}
+        {{ .Data.MaxSpeed | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
       </div>
     </div>
   </div>

--- a/views/partials/workout_point_title.html
+++ b/views/partials/workout_point_title.html
@@ -5,13 +5,25 @@ Javascript string. I hope to find a better solution than this... #} {{- define
   {{- "" -}}
   <li><b>{{ i18n "Time" }}:</b> {{ (.Time | LocalTime).Format "15:04" }}</li>
   {{- "" -}}
-  <li><b>{{ i18n "Distance" }}:</b> {{ .TotalDistance | HumanDistance }}</li>
+  <li>
+    {{- "" -}}
+    <b>{{ i18n "Distance" }}:</b> {{ .TotalDistance | HumanDistance }} {{
+    CurrentUser.PreferredUnits.Distance }} {{- "" -}}
+  </li>
   {{- "" -}}
   <li><b>{{ i18n "Duration" }}:</b> {{ .TotalDuration | HumanDuration }}</li>
   {{- "" -}}
-  <li><b>{{ i18n "Speed" }}:</b> {{ .AverageSpeed | HumanSpeed }}</li>
+  <li>
+    {{- "" -}}
+    <b>{{ i18n "Speed" }}:</b> {{ .AverageSpeed | HumanSpeed }} {{
+    CurrentUser.PreferredUnits.Speed }} {{- "" -}}
+  </li>
   {{- "" -}}
-  <li><b>{{ i18n "Elevation" }}:</b> {{ .Elevation | HumanElevation }}</li>
+  <li>
+    {{- "" -}}
+    <b>{{ i18n "Elevation" }}:</b> {{ .Elevation | HumanElevation }} {{
+    CurrentUser.PreferredUnits.Elevation }} {{- "" -}}
+  </li>
   {{- "" -}}
 </ol>
 {{- end -}}

--- a/views/workouts/workouts_list.html
+++ b/views/workouts/workouts_list.html
@@ -62,7 +62,8 @@
               sorttable_customkey="{{ .Data.TotalDistance }}"
               class="whitespace-nowrap font-mono"
             >
-              {{ .Data.TotalDistance | HumanDistance }}
+              {{ .Data.TotalDistance | HumanDistance }} {{
+              CurrentUser.PreferredUnits.Distance }}
             </td>
             <td
               class="hidden sm:table-cell whitespace-nowrap font-mono"
@@ -74,19 +75,22 @@
               class="hidden 2xl:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.AverageSpeedNoPause }}"
             >
-              {{ .Data.AverageSpeedNoPause | HumanSpeed }}
+              {{ .Data.AverageSpeedNoPause | HumanSpeed }} {{
+              CurrentUser.PreferredUnits.Speed }}
             </td>
             <td
               class="hidden 2xl:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.AverageSpeedNoPause }}"
             >
-              {{ .Data.AverageSpeedNoPause | HumanTempo }}
+              {{ .Data.AverageSpeedNoPause | HumanTempo }} {{
+              CurrentUser.PreferredUnits.Tempo }}
             </td>
             <td
               class="hidden 2xl:table-cell whitespace-nowrap font-mono"
               sorttable_customkey="{{ .Data.MaxSpeed }}"
             >
-              {{ .Data.MaxSpeed | HumanSpeed }}
+              {{ .Data.MaxSpeed | HumanSpeed }} {{
+              CurrentUser.PreferredUnits.Speed }}
             </td>
             <td class="hidden lg:table-cell">
               <span class="actions"> {{ template "workout_actions" . }} </span>


### PR DESCRIPTION
- Remove units from Human* functions to return only numerical value Update     s
- affected templates to include units based on CurrentUser.PreferredUnit       s

This commit refactors the Human* functions to remove the units from the returned values, and updates the affected templates to include the units based on the CurrentUser.PreferredUnits.