### PR TITLE
Prevent duplicate MapData entries

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -215,8 +215,23 @@ func (w *Workout) UpdateData(db *gorm.DB) error {
 		return err
 	}
 
+	dataID := uint(0)
+	dataCreatedAt := time.Now()
+
+	if w.Data != nil {
+		dataID = w.Data.ID
+		dataCreatedAt = w.Data.CreatedAt
+	}
+
 	w.Data = gpxAsMapData(gpxContent)
+	w.Data.ID = dataID
+	w.Data.CreatedAt = dataCreatedAt
+
+	if err := w.Data.Save(db); err != nil {
+		return err
+	}
+
 	w.Dirty = false
 
-	return db.Save(w).Error
+	return w.Save(db)
 }


### PR DESCRIPTION
The MapData was saved again and again to the database, as new records, upon refresh.

We now keep track of the old ID and CreatedAt values, which should update the existing record instead of creating new records.