### PR TITLE
Switch the timestamp detection in a GPX file

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -140,7 +140,7 @@ func autoDetectWorkoutType(data *MapData, gpxContent *gpx.GPX) WorkoutType {
 		return WorkoutTypeCycling
 	}
 
-	if 3.6*data.AverageSpeedNoPause() > 5.0 {
+	if 3.6*data.AverageSpeedNoPause() > 7.0 {
 		return WorkoutTypeRunning
 	}
 

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -182,22 +182,21 @@ func gpxName(gpxContent *gpx.GPX) string {
 
 // Determines the date to use for the workout
 func gpxDate(gpxContent *gpx.GPX) *time.Time {
-	// If a date is specified in the metadata, use that (not all apps have this, notably Workoutdoors doesn't)
-	if gpxContent.Time != nil {
-		return gpxContent.Time
-	}
-
-	// Otherwise use the first track's first segment's timestamp
+	// Use the first track's first segment's timestamp if it exists
+	// This is the best time to use as a start time, since converters shouldn't
+	// touch this timestamp
 	if len(gpxContent.Tracks) > 0 {
-		if len(gpxContent.Tracks[0].Segments) > 0 {
-			if len(gpxContent.Tracks[0].Segments[0].Points) > 0 {
-				return &gpxContent.Tracks[0].Segments[0].Points[0].Timestamp
+		if t := gpxContent.Tracks[0]; len(t.Segments) > 0 {
+			if s := t.Segments[0]; len(s.Points) > 0 {
+				return &s.Points[0].Timestamp
 			}
 		}
 	}
 
-	// This is not good as the database requires date to be set, but we don't know any suitable date...
-	return nil
+	// Otherwise, return the timestamp from the metadata, use that (not all apps have
+	// this, notably Workoutdoors doesn't)
+	// If this is nil, this should result in an error and the user will be alerted.
+	return gpxContent.Time
 }
 
 func distanceBetween(p1 gpx.GPXPoint, p2 gpx.GPXPoint) float64 {


### PR DESCRIPTION
This takes the first time from the first point in the GPX file as the time of the workout, instead of the timestamp from the metadata. The timestamp from the metadata is then used as fallback, but may have been altered by converters.

We also change the auto-detection algorithm, so the limit of running vs walking is now 7 instead of 5 km/h.

Fixes #57