### PR TITLE
Ensure the workout-mapdata relation is a 1-1 mapping

### DIFF
--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -45,7 +45,7 @@ func correctAltitude(creator string, lat, long, alt float64) float64 {
 
 type MapData struct {
 	gorm.Model
-	WorkoutID     uint `gorm:"not null"`
+	WorkoutID     uint `gorm:"not null;uniqueIndex"`
 	Creator       string
 	Name          string
 	Center        MapCenter    `gorm:"serializer:json"`

--- a/pkg/database/workouts_test.go
+++ b/pkg/database/workouts_test.go
@@ -73,9 +73,9 @@ func TestWorkout_UpdateData(t *testing.T) {
 	require.NoError(t, w.Save(db))
 
 	ud := w.UpdatedAt
-	d := w.Data
 
-	w.Data = dummyMapData()
+	d := w.Data
+	w.setData(dummyMapData())
 	require.NoError(t, w.Save(db))
 
 	assert.NotEqual(t, d, w.Data)


### PR DESCRIPTION
We add an uniqueIndex constraint on the WorkoutID column, to ensure it remains a 1-1 relation. Since there may already be duplicate records in the table, we need to perform a pre-migration cleanup. This may happen before the table is even created (first run), so we need to check if the table exists.

We also update our tests, since they seemed to add extra records!