### PR TITLE
Ensure a user can not have two workouts with the same time

### DIFF
--- a/pkg/database/gorm.go
+++ b/pkg/database/gorm.go
@@ -70,7 +70,16 @@ func preMigrationActions(db *gorm.DB) error {
 		return nil
 	}
 
-	q := db.Unscoped().Where("id < (select max(id) from map_data as m where m.workout_id = map_data.workout_id)").Delete(&MapData{})
+	q := db.Unscoped().
+		Where("id < (select max(id) from map_data as m where m.workout_id = map_data.workout_id)").
+		Delete(&MapData{})
+	if q.Error != nil {
+		return q.Error
+	}
+
+	q = db.Unscoped().
+		Where("id < (select max(id) from workouts as w where w.date = workouts.date and w.user_id = workouts.user_id)").
+		Delete(&Workout{})
 
 	return q.Error
 }

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -20,9 +20,9 @@ var ErrInvalidData = errors.New("could not convert data to a GPX structure")
 
 type Workout struct {
 	gorm.Model
-	Name   string      `gorm:"not null"`       // The name of the workout
-	Date   *time.Time  `gorm:"not null"`       // The timestamp the workout was recorded
-	UserID uint        `gorm:"not null;index"` // The ID of the user who owns the workout
+	Name   string      `gorm:"not null"`                                  // The name of the workout
+	Date   *time.Time  `gorm:"not null;uniqueIndex:idx_start_user"`       // The timestamp the workout was recorded
+	UserID uint        `gorm:"not null;index;uniqueIndex:idx_start_user"` // The ID of the user who owns the workout
 	Dirty  bool        // Whether the workout has been modified and the details should be re-rendered
 	User   *User       // The user who owns the workout
 	Notes  string      // The notes associated with the workout, in markdown


### PR DESCRIPTION
This would mean the user has uploaded multiple files with the same (partial) workout, which is not what the user wants.

We also delete any current entries with the same date and user id, except the last one of each tuple.

Fixes #94