### PR TITLE
Add support for submitting workouts via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ If no users are in the database (eg. when starting with an empty database), a
 default `admin` user is created with password `admin`. You should change this
 password in a production environment.
 
+## API usage
+
+The API is documented using [swagger](https://swagger.io/). You must enable API access for your user, and copy the API key. You can use the API key as a query parameter (`api-key=${API_KEY}`) or as a header (`Authorization: Bearer ${API_KEY}`).
+
+You can configure some tools to automatically upload files to Workout Tracker, using the `POST /api/v1/import/$program` API endpoint.
+
+### FitoTrack
+
+Read [their documentation](https://codeberg.org/jannis/FitoTrack/wiki/Auto-Export) before you continue.
+
+The path to POST to is: `/api/v1/import/fitotrack?api-key=${API_KEY}`
+
 ## Development
 
 ### Build and run it yourself

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -21,6 +21,61 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/import/{program}": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Import a workout",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Program that generates the workout file",
+                        "name": "program",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/app.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/database.Workout"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/records": {
             "get": {
                 "produces": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14,6 +14,61 @@
     },
     "basePath": "/api/v1",
     "paths": {
+        "/import/{program}": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Import a workout",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Program that generates the workout file",
+                        "name": "program",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/app.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "result": {
+                                            "$ref": "#/definitions/database.Workout"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/records": {
             "get": {
                 "produces": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -484,6 +484,39 @@ info:
   title: Workout Tracker
   version: "1.0"
 paths:
+  /import/{program}:
+    post:
+      parameters:
+      - description: Program that generates the workout file
+        in: path
+        name: program
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/app.APIResponse'
+            - properties:
+                result:
+                  $ref: '#/definitions/database.Workout'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+      summary: Import a workout
   /records:
     get:
       parameters:

--- a/pkg/app/data.go
+++ b/pkg/app/data.go
@@ -31,7 +31,6 @@ func (a *App) setUser(c echo.Context) error {
 
 	c.Set("user_info", dbUser)
 	c.Set("user_language", dbUser.Profile.Language)
-	c.Set("user_totals_show", dbUser.Profile.TotalsShow)
 
 	return nil
 }

--- a/pkg/converters/tcx.go
+++ b/pkg/converters/tcx.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/galeone/tcx"
 	"github.com/tkrajina/gpxgo/gpx"
 )
@@ -52,10 +51,6 @@ func ParseTCX(tcxFile []byte) (*gpx.GPX, error) {
 			}
 		}
 	}
-
-	spew.Dump(g.Tracks[0].Duration())
-	// spew.Dump(g)
-	// panic("stop")
 
 	return g, nil
 }

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -79,6 +79,9 @@ func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string,
 	}
 
 	data := gpxAsMapData(gpxContent)
+	if filename == "" {
+		filename = data.Name + ".gpx"
+	}
 
 	h := sha256.New()
 	h.Write(content)

--- a/pkg/importers/fitotrack.go
+++ b/pkg/importers/fitotrack.go
@@ -1,0 +1,31 @@
+package importers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func importFitotrack(headers http.Header, body io.ReadCloser) (*Content, error) {
+	if t := headers.Get("FitoTrack-Type"); t != "workout-gpx" {
+		return nil, fmt.Errorf("unsupported FitoTrack-Type: %s", t)
+	}
+
+	wt := headers.Get("FitoTrack-Workout-Type")
+	wn := headers.Get("FitoTrack-Comment")
+
+	defer body.Close()
+
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	g := &Content{
+		Content: b,
+		Type:    wt,
+		Notes:   wn,
+	}
+
+	return g, nil
+}

--- a/pkg/importers/importer.go
+++ b/pkg/importers/importer.go
@@ -1,0 +1,25 @@
+package importers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var ErrUnsupportedProgram = errors.New("unsupported program")
+
+type Content struct {
+	Content  []byte
+	Filename string
+	Notes    string
+	Type     string
+}
+
+func Import(program string, headers http.Header, body io.ReadCloser) (*Content, error) {
+	if program == "fitotrack" {
+		return importFitotrack(headers, body)
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrUnsupportedProgram, program)
+}

--- a/translations/de.json
+++ b/translations/de.json
@@ -91,6 +91,7 @@
   "edit": "bearbeiten",
   "feet": "feet",
   "generate a new API key": "Neuen API-Schlüssel generieren",
+  "how to use": "how to use",
   "kilometers": "kilometers",
   "kilometers per hour": "kilometers per hour",
   "meters": "meters",

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -91,6 +91,7 @@
   "edit": "edit",
   "feet": "feet",
   "generate a new API key": "generate a new API key",
+  "how to use": "how to use",
   "kilometers": "kilometers",
   "kilometers per hour": "kilometers per hour",
   "meters": "meters",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -91,6 +91,7 @@
   "edit": "bewerk",
   "feet": "voet",
   "generate a new API key": "maak een nieuwe API-sleutel",
+  "how to use": "hoe te gebruiken",
   "kilometers": "kilometers",
   "kilometers per hour": "kilometers per uur",
   "meters": "meters",

--- a/views/user/user_profile.html
+++ b/views/user/user_profile.html
@@ -14,7 +14,17 @@
             <tbody>
               <tr>
                 <th>
-                  <label for="api_active">{{ i18n "Enable API access" }}</label>
+                  <label for="api_active"
+                    >{{ i18n "Enable API access" }}
+
+                    <a
+                      class="{{ IconFor `info` }}"
+                      title="{{ i18n `how to use` }}"
+                      target="_blank"
+                      href="https://github.com/jovandeginste/workout-tracker?tab=readme-ov-file#api-usage"
+                      >&nbsp;</a
+                    >
+                  </label>
                 </th>
                 <td class="flex flex-wrap gap-5">
                   <input
@@ -27,7 +37,6 @@
                     .Profile.APIActive
                     }}
                   />
-
                   {{ if .Profile.APIActive }}
                   <input
                     type="password"


### PR DESCRIPTION
This adds support for FitoTrack to automatically upload workouts via HTTP POST. We had to add authentication via query parameter, since FitoTrack did not support Header or BasicAuth authentication.

We also now have a README section that can be extended.