### PR TITLE
Fix the graph async in the workout statistics

### DIFF
--- a/views/partials/workout_show_stats.html
+++ b/views/partials/workout_show_stats.html
@@ -111,7 +111,7 @@
           yAxisID: 'y',
           data: [
             {{ range .Items -}}
-            { "x": {{ .LastPoint.Time }}, "y": {{ .Speed | HumanSpeed }}, "lat": "{{ .LastPoint.Lat }}", "lng": "{{ .LastPoint.Lng }}", label: "{{ template `workout_point_title` .LastPoint }}" },
+            { "x": {{ .FirstPoint.Time }}, "y": {{ .Speed | HumanSpeed }}, "lat": "{{ .FirstPoint.Lat }}", "lng": "{{ .FirstPoint.Lng }}", label: "{{ template `workout_point_title` .FirstPoint }}" },
             {{- end  }}
           ],
         },


### PR DESCRIPTION
We were comparing first & last points in the same graphs, which offset the lines by one minute...