### PR TITLE
Show the totals/records for the selected user

### DIFF
--- a/views/partials/stats_records_totals.html
+++ b/views/partials/stats_records_totals.html
@@ -1,4 +1,4 @@
-{{ define "stats_records_total" }} {{ with CurrentUser.GetDefaultTotals }}
+{{ define "stats_records_total" }} {{ with .GetDefaultTotals }}
 <div class="md:flex md:flex-wrap">
   {{ $di := i18n "distance" }} {{ $w := i18n "workouts"}} {{ $u := i18n "up" }}
   {{ $du := i18n "duration" }} {{ template "statistic_tile"

--- a/views/user/user_show.html
+++ b/views/user/user_show.html
@@ -10,12 +10,12 @@
         {{ i18n "Dashboard for %s" .user.Name }}
       </h2>
 
-      {{ template "stats_records_total" }}
+      {{ template "stats_records_total" .user }}
 
       <div class="lg:flex lg:flex-wrap [&>*]:basis-1/2">
         <div>
-          {{ range CurrentUser.GetAllRecords }} {{ if and
-          .WorkoutType.IsDistance .Active }}
+          {{ range .user.GetAllRecords }} {{ if and .WorkoutType.IsDistance
+          .Active }}
           <div class="inner-form">
             {{ template "stats_records_distance" . }}
           </div>


### PR DESCRIPTION
Instead of showing the authenticated user's information, we should show the selected user's totals and records. We still use the authenticated user's preferred units.

Fixes #120