### PR TITLE
fix: call date in a different way from the Makefile to fix build error on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GIT_REF ?= $(shell git symbolic-ref HEAD)
 GIT_REF_NAME ?= $(shell git branch --show-current)
 GIT_REF_TYPE ?= branch
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
-BUILD_TIME ?= $(shell date -u --rfc-3339=seconds)
+BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 OUTPUT_FILE ?= tmp/main
 
 I18N_LANGUAGES ?= nl de fr


### PR DESCRIPTION
On macOS, calling `date` with `--rfc3339` is not supported, this PR makes it use a different incantation (that as far as I can see also works on Linux). The date it produces is in a slightly different format, not sure where this is used anyway?

![image](https://github.com/jovandeginste/workout-tracker/assets/181337/cf89000b-b90f-45ff-b5f9-24246ca0f112)