### PR TITLE
Fix/dark map colors

### DIFF
--- a/assets/output.css
+++ b/assets/output.css
@@ -455,11 +455,10 @@ video {
 
 @media (prefers-color-scheme: dark) {
   .map-tiles {
-    --tw-brightness: brightness(0.6);
-    --tw-contrast: contrast(3);
-    --tw-hue-rotate: hue-rotate(200deg);
+    --tw-brightness: brightness(0.85);
+    --tw-contrast: contrast(0.80);
     --tw-invert: invert(100%);
-    --tw-saturate: saturate(0.3);
+    --tw-saturate: saturate(0.0);
     filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
   }
 }

--- a/main.css
+++ b/main.css
@@ -9,7 +9,7 @@
   }
 
   .map-tiles {
-    @apply dark:brightness-[0.6] dark:invert dark:contrast-[3] dark:hue-rotate-[200deg] dark:saturate-[0.3];
+    @apply dark:saturate-[0.0] dark:invert dark:contrast-[0.80] dark:brightness-[0.85];
   }
 
   table.sortable


### PR DESCRIPTION
Tweak the map styling in dark mode, so it looks a bit better (the map is fully monochrome now, so the route is more easy to distinguish)

See below for a before (left) and after (right)

![image](https://github.com/jovandeginste/workout-tracker/assets/181337/a21bb999-984d-4cd6-b094-47dc2f30d733)
