### PR TITLE
Fix disabling options in profile settings

### DIFF
--- a/pkg/app/self_handlers.go
+++ b/pkg/app/self_handlers.go
@@ -39,6 +39,8 @@ func (a *App) userProfileUpdateHandler(c echo.Context) error {
 	u := a.getCurrentUser(c)
 	p := &u.Profile
 
+	p.ResetBools()
+
 	if err := c.Bind(p); err != nil {
 		return a.redirectWithError(c, a.echo.Reverse("user-profile"), err)
 	}

--- a/pkg/database/profile.go
+++ b/pkg/database/profile.go
@@ -68,6 +68,12 @@ func (u UserPreferredUnits) Speed() string {
 	}
 }
 
+func (p *Profile) ResetBools() {
+	p.PreferFullDate = false
+	p.APIActive = false
+	p.SocialsDisabled = false
+}
+
 func (p *Profile) Save(db *gorm.DB) error {
 	return db.Save(p).Error
 }


### PR DESCRIPTION
Unchecking options like API access was not working, because unchecked checkboxes are not sent as form values.

This change first unsets all booleans, which may or may not be enabled again through the form.