### PR TITLE
Add generic "import" endpoint to API

### DIFF
--- a/assets/output.css
+++ b/assets/output.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.4.3 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.4 | MIT License | https://tailwindcss.com
 */
 
 /*

--- a/pkg/importers/fitotrack.go
+++ b/pkg/importers/fitotrack.go
@@ -14,18 +14,13 @@ func importFitotrack(headers http.Header, body io.ReadCloser) (*Content, error) 
 	wt := headers.Get("FitoTrack-Workout-Type")
 	wn := headers.Get("FitoTrack-Comment")
 
-	defer body.Close()
-
-	b, err := io.ReadAll(body)
+	b, err := importGeneric(headers, body)
 	if err != nil {
 		return nil, err
 	}
 
-	g := &Content{
-		Content: b,
-		Type:    wt,
-		Notes:   wn,
-	}
+	b.Type = wt
+	b.Notes = wn
 
-	return g, nil
+	return b, nil
 }

--- a/pkg/importers/generic.go
+++ b/pkg/importers/generic.go
@@ -1,0 +1,20 @@
+package importers
+
+import (
+	"io"
+	"net/http"
+)
+
+func importGeneric(_ http.Header, body io.ReadCloser) (*Content, error) {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	g := &Content{
+		Content: b,
+		Type:    "auto",
+	}
+
+	return g, nil
+}

--- a/pkg/importers/importer.go
+++ b/pkg/importers/importer.go
@@ -17,9 +17,14 @@ type Content struct {
 }
 
 func Import(program string, headers http.Header, body io.ReadCloser) (*Content, error) {
-	if program == "fitotrack" {
-		return importFitotrack(headers, body)
-	}
+	defer body.Close()
 
-	return nil, fmt.Errorf("%w: %s", ErrUnsupportedProgram, program)
+	switch program {
+	case "generic":
+		return importGeneric(headers, body)
+	case "fitotrack":
+		return importFitotrack(headers, body)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedProgram, program)
+	}
 }


### PR DESCRIPTION
This allows importing a GPX file without any further metadata. The workout type (running, walking, cycling) will then be inferred automatically, similar to uploading it through the web UI.