### PR TITLE
Don't show missing location when not location based

### DIFF
--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -6,11 +6,13 @@
       <th>{{ i18n "Date" }}</th>
       <td>{{ template "snippet_date" .Date }}</td>
     </tr>
+    {{ if .Type.IsLocation }}
     <tr>
       <td class="{{ IconFor `location` }}"></td>
       <th>{{ i18n "Location" }}</th>
       <td>{{ .Data.AddressString }}</td>
     </tr>
+    {{ end }}
     <tr>
       <td class="{{ IconFor `source` }}"></td>
       <th>{{ i18n "Source" }}</th>


### PR DESCRIPTION
If a workout is not a location-based workout, don't show the location: it will always be missing, so not useful.