### PR TITLE
Parse extention nodes and standardize extra metric names

### DIFF
--- a/assets/output.css
+++ b/assets/output.css
@@ -2560,6 +2560,14 @@ table {
   content: "\f017";
 }
 
+.icon-compass::before {
+  content: "\f14e";
+}
+
+.icon-compass::after {
+  content: "\f14e";
+}
+
 .icon-download::before {
   content: "\f019";
 }

--- a/pkg/converters/fit.go
+++ b/pkg/converters/fit.go
@@ -58,13 +58,13 @@ func ParseFit(fitFile []byte) (*gpx.GPX, error) {
 
 		if r.HeartRate != 0xFF {
 			p.Extensions.Nodes = append(p.Extensions.Nodes, gpx.ExtensionNode{
-				XMLName: xml.Name{Local: "ns3:hr"}, Data: strconv.Itoa(int(r.HeartRate)),
+				XMLName: xml.Name{Local: "heart-rate"}, Data: strconv.Itoa(int(r.HeartRate)),
 			})
 		}
 
 		if r.Cadence != 0xFF {
 			p.Extensions.Nodes = append(p.Extensions.Nodes, gpx.ExtensionNode{
-				XMLName: xml.Name{Local: "ns3:cad"}, Data: strconv.Itoa(int(r.Cadence)),
+				XMLName: xml.Name{Local: "cadence"}, Data: strconv.Itoa(int(r.Cadence)),
 			})
 		}
 

--- a/pkg/database/extra_metrics.go
+++ b/pkg/database/extra_metrics.go
@@ -17,22 +17,42 @@ func (em ExtraMetrics) Get(key string) float64 {
 }
 
 func (em ExtraMetrics) ParseGPXExtensions(extension gpx.Extension) {
-	for i := range extension.Nodes {
-		key, value := getGPXExtensionKeyValue(&extension.Nodes[i])
-		if key == "" {
-			continue
+	for _, n := range extension.Nodes {
+		if key, value := getGPXExtensionKeyValue(&n); key != "" {
+			em.Set(key, value)
 		}
 
-		em.Set(key, value)
+		for _, subN := range n.Nodes {
+			if key, value := getGPXExtensionKeyValue(&subN); key != "" {
+				em.Set(key, value)
+			}
+		}
 	}
 }
 
 func getGPXExtensionKeyValue(n *gpx.ExtensionNode) (string, float64) {
-	name := n.XMLName.Local
+	name := standardExtensionName(n.XMLName.Local)
 
 	if data, err := strconv.ParseFloat(n.Data, 64); err == nil {
 		return name, data
 	}
 
 	return "", 0
+}
+
+func standardExtensionName(name string) string {
+	switch name {
+	case "course":
+		return "heading"
+	case "hAcc": // horizontal accuracy estimate [mm]
+		return "horizontal-accuracy"
+	case "vAcc": // vertical accuracy estimate [mm]
+		return "vertical-accuracy"
+	case "ns3:hr", "hr":
+		return "heart-rate"
+	case "ns3:cad", "cad":
+		return "cadence"
+	default:
+		return name
+	}
 }

--- a/pkg/database/user_test.go
+++ b/pkg/database/user_test.go
@@ -306,6 +306,9 @@ func TestDatabaseUserWorkouts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, workouts, 1)
 
+	assert.True(t, w2.HasElevation())
+	assert.True(t, w2.HasHeartRate())
+
 	w2.Type = WorkoutTypeWalking
 	require.NoError(t, w2.Save(db))
 }

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -267,15 +267,19 @@ func (w *Workout) UpdateData(db *gorm.DB) error {
 }
 
 func (w *Workout) HasElevation() bool {
-	return w.HasExtraMetric("Elevation")
+	return w.HasExtraMetric("elevation")
 }
 
 func (w *Workout) HasCadence() bool {
-	return w.HasExtraMetric("ns3:cad")
+	return w.HasExtraMetric("cadence")
 }
 
 func (w *Workout) HasHeartRate() bool {
-	return w.HasExtraMetric("ns3:hr")
+	return w.HasExtraMetric("heart-rate")
+}
+
+func (w *Workout) HasHeading() bool {
+	return w.HasExtraMetric("heading")
 }
 
 func (w *Workout) HasExtraMetric(name string) bool {

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -361,7 +361,7 @@ func gpxAsMapData(gpxContent *gpx.GPX) *MapData {
 		totalTime += t
 
 		extraMetrics := ExtraMetrics{}
-		extraMetrics.Set("Elevation", correctAltitude(gpxContent.Creator, pt.Point.Latitude, pt.Point.Longitude, pt.Elevation.Value()))
+		extraMetrics.Set("elevation", correctAltitude(gpxContent.Creator, pt.Point.Latitude, pt.Point.Longitude, pt.Elevation.Value()))
 		extraMetrics.ParseGPXExtensions(pt.Extensions)
 
 		data.Details.Points = append(data.Details.Points, MapPoint{

--- a/pkg/templatehelpers/icons.go
+++ b/pkg/templatehelpers/icons.go
@@ -44,10 +44,12 @@ func categoryIcon(what string) string {
 		return iconDefaults + " icon-solid icon-calculator"
 	case "weight":
 		return iconDefaults + " icon-solid icon-weight-hanging"
-	case "heartrate":
+	case "heart-rate":
 		return iconDefaults + " icon-solid icon-heart-pulse"
 	case "cadence":
 		return iconDefaults + " icon-solid icon-stopwatch"
+	case "heading":
+		return iconDefaults + " icon-solid icon-compass"
 	case "date":
 		return iconDefaults + " icon-regular icon-calendar"
 	case "pause":

--- a/translations/de.json
+++ b/translations/de.json
@@ -38,6 +38,7 @@
     "Equipment": "Ausrüstung",
     "Extra metrics": "Extra metrics",
     "File": "Datei",
+    "Heading": "Heading",
     "Heart rate": "Herzfrequenz",
     "I completed a workout: %s.": "Ich habe das Training %s absolviert.",
     "It took me %s to go %s. I averaged %s.": "Es hat mich %s gekostet, um %s zu gehen. Ich habe im Durchschnitt %s.",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -38,6 +38,7 @@
     "Equipment": "Équipement",
     "Extra metrics": "Extra metrics",
     "File": "Fichier",
+    "Heading": "Heading",
     "Heart rate": "Rythme cardiaque",
     "I completed a workout: %s.": "J'ai terminé une séance d'entraînement : %s.",
     "It took me %s to go %s. I averaged %s.": "Il m'a fallu %s pour aller %s. J'ai fait la moyenne de %s.",

--- a/translations/it.json
+++ b/translations/it.json
@@ -38,6 +38,7 @@
     "Equipment": "Attrezzatura",
     "Extra metrics": "Extra metrics",
     "File": "File",
+    "Heading": "Heading",
     "Heart rate": "Frequenza cardiaca",
     "I completed a workout: %s.": "Ho completato un allenamento: %s.",
     "It took me %s to go %s. I averaged %s.": "Mi ci è voluto %s per andare %s. Ho mantenuto una media di %s.",

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -38,6 +38,7 @@
     "Equipment": "Equipment",
     "Extra metrics": "Extra metrics",
     "File": "File",
+    "Heading": "Heading",
     "Heart rate": "Heart rate",
     "I completed a workout: %s.": "I completed a workout: %s.",
     "It took me %s to go %s. I averaged %s.": "It took me %s to go %s. I averaged %s.",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -38,6 +38,7 @@
     "Equipment": "Materiaal",
     "Extra metrics": "Extra informatie",
     "File": "Bestand",
+    "Heading": "Koers",
     "Heart rate": "Hartslag",
     "I completed a workout: %s.": "Ik heb een workout voltooid: %s.",
     "It took me %s to go %s. I averaged %s.": "Het duurde %s om %s te bereiken. Ik haalde gemiddeld %s.",

--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -151,10 +151,12 @@
         {{ if .HasHeartRate }}
         <div
           title="{{ i18n `Heart rate` }}"
-          class="{{ IconFor `heartrate` }}"
+          class="{{ IconFor `heart-rate` }}"
         ></div>
-        {{ end }} {{ if .HasCadence }}
+        {{ end }}{{ if .HasCadence }}
         <div title="{{ i18n `Cadence` }}" class="{{ IconFor `cadence` }}"></div>
+        {{ end }}{{ if .HasHeading }}
+        <div title="{{ i18n `Heading` }}" class="{{ IconFor `heading` }}"></div>
         {{ end }}
       </td>
     </tr>

--- a/views/partials/workout_point_title.html
+++ b/views/partials/workout_point_title.html
@@ -21,7 +21,7 @@ Javascript string. I hope to find a better solution than this... #} {{- define
   {{- "" -}}
   <li>
     {{- "" -}}
-    <b>{{ i18n "Elevation" }}:</b> {{ .ExtraMetrics.Get "Elevation" |
+    <b>{{ i18n "Elevation" }}:</b> {{ .ExtraMetrics.Get "elevation" |
     HumanElevation }} {{ CurrentUser.PreferredUnits.Elevation }} {{- "" -}}
   </li>
   {{- "" -}}

--- a/views/partials/workout_show_stats.html
+++ b/views/partials/workout_show_stats.html
@@ -62,7 +62,7 @@
         type: "area",
         data: [
           {{ range .Items -}}
-          { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "Elevation" | HumanElevation }}, },
+          { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "elevation" | HumanElevation }}, },
           {{- end  }}
         ],
       },
@@ -72,7 +72,7 @@
         display: false,
         data: [
           {{ range .Items -}}
-          { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "ns3:hr" }}, },
+          { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "heart-rate" }}, },
           {{- end  }}
         ],
       },
@@ -82,7 +82,7 @@
         display: false,
         data: [
           {{ range .Items -}}
-          { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "ns3:cad" }}, },
+          { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "cadence" }}, },
           {{- end  }}
         ],
       },

--- a/views/workouts/workouts_show.html
+++ b/views/workouts/workouts_show.html
@@ -53,7 +53,7 @@
                   points: [
                     {{ with .Data.Details }}
                     {{ range .Points -}}
-                    { "lat": {{ .Lat }}, "lng": {{ .Lng }}, "speed": {{ .AverageSpeed }}, "elevation": {{ .ExtraMetrics.Get "Elevation" }}, "title": "{{ template `workout_point_title` . }}", },
+                    { "lat": {{ .Lat }}, "lng": {{ .Lng }}, "speed": {{ .AverageSpeed }}, "elevation": {{ .ExtraMetrics.Get "elevation" }}, "title": "{{ template `workout_point_title` . }}", },
                     {{ end  }}
                     {{ end  }}
                   ]


### PR DESCRIPTION
This adds better support for Apple Health GPX files, and provides a standardized way to store the extra metric names.

We also parse a few extra metrics, but don't have a way to show them for now (if ever). Only a visual cue to show whether there is heading information in the GPX points.