### PR TITLE
Skip updates for non-GPX based workouts

### DIFF
--- a/pkg/app/background.go
+++ b/pkg/app/background.go
@@ -22,17 +22,27 @@ const (
 )
 
 func (a *App) BackgroundWorker() {
-	l := a.logger.With("module", "worker")
-
 	for {
-		l.Info("Worker started...")
-
-		a.updateWorkout(l)
-		a.autoImports(l)
-
-		l.Info("Worker finished...")
+		a.bgLoop()
 		time.Sleep(WorkerDelay)
 	}
+}
+
+func (a *App) bgLoop() {
+	l := a.logger.With("module", "worker")
+
+	defer func() {
+		if r := recover(); r != nil {
+			l.Error(fmt.Sprintf("Panic in bgLoop: %#v", r))
+		}
+	}()
+
+	l.Info("Worker started...")
+
+	a.updateWorkout(l)
+	a.autoImports(l)
+
+	l.Info("Worker finished...")
 }
 
 func (a *App) autoImports(l *slog.Logger) {

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -232,6 +232,10 @@ func (w *Workout) Save(db *gorm.DB) error {
 }
 
 func (w *Workout) AsGPX() (*gpx.GPX, error) {
+	if w.GPX == nil {
+		return nil, errors.New("workout has no GPX")
+	}
+
 	return converters.Parse(w.GPX.Filename, w.GPX.Content)
 }
 
@@ -250,6 +254,11 @@ func (w *Workout) setData(data *MapData) {
 }
 
 func (w *Workout) UpdateData(db *gorm.DB) error {
+	if w.GPX == nil {
+		// We only update data from (stored) GPX data
+		return nil
+	}
+
 	gpxContent, err := w.AsGPX()
 	if err != nil {
 		return err


### PR DESCRIPTION
There is nothing to update there (for now)...
Also generically catch any panic in the background loop and recover from it with a message.