### PR TITLE
fix: support editing workouts using Imperial units

### DIFF
--- a/assets/output.css
+++ b/assets/output.css
@@ -502,8 +502,7 @@ ul {
   list-style-type: disc;
 }
 
-button[type="submit"],
-  textarea,
+textarea,
   select,
   input {
   border-radius: 0.75rem;
@@ -518,29 +517,19 @@ button[type="submit"],
   background-color: rgb(244 244 245 / var(--tw-bg-opacity));
 }
 
-button[type="submit"]::-moz-placeholder, textarea::-moz-placeholder, select::-moz-placeholder, input::-moz-placeholder {
+textarea::-moz-placeholder, select::-moz-placeholder, input::-moz-placeholder {
   --tw-text-opacity: 1;
   color: rgb(100 116 139 / var(--tw-text-opacity));
 }
 
-button[type="submit"]::placeholder,
-  textarea::placeholder,
+textarea::placeholder,
   select::placeholder,
   input::placeholder {
   --tw-text-opacity: 1;
   color: rgb(100 116 139 / var(--tw-text-opacity));
 }
 
-button[type="submit"]:hover,
-  textarea:hover,
-  select:hover,
-  input:hover {
-  --tw-border-opacity: 1;
-  border-color: rgb(245 158 11 / var(--tw-border-opacity));
-}
-
 @media (prefers-color-scheme: dark) {
-  button[type="submit"],
   textarea,
   select,
   input {
@@ -550,30 +539,103 @@ button[type="submit"]:hover,
     background-color: rgb(24 24 27 / var(--tw-bg-opacity));
   }
 
-  button[type="submit"]::-moz-placeholder, textarea::-moz-placeholder, select::-moz-placeholder, input::-moz-placeholder {
+  textarea::-moz-placeholder, select::-moz-placeholder, input::-moz-placeholder {
     --tw-text-opacity: 1;
     color: rgb(100 116 139 / var(--tw-text-opacity));
   }
 
-  button[type="submit"]::placeholder,
   textarea::placeholder,
   select::placeholder,
   input::placeholder {
     --tw-text-opacity: 1;
     color: rgb(100 116 139 / var(--tw-text-opacity));
   }
+}
 
-  button[type="submit"]:hover,
-  textarea:hover,
+textarea:hover,
   select:hover,
   input:hover {
-    --tw-border-opacity: 1;
-    border-color: rgb(245 158 11 / var(--tw-border-opacity));
+  --tw-brightness: brightness(1.25);
+  --tw-contrast: contrast(1.25);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+textarea:focus,
+  select:focus,
+  input:focus {
+  --tw-brightness: brightness(1.25);
+  --tw-contrast: contrast(1.25);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+button.edit {
+  --tw-border-opacity: 1;
+  border-color: rgb(251 191 36 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 211 77 / var(--tw-bg-opacity));
+}
+
+@media (prefers-color-scheme: dark) {
+  button.edit {
+    --tw-bg-opacity: 1;
+    background-color: rgb(245 158 11 / var(--tw-bg-opacity));
   }
 }
 
-button[type="submit"] {
+button.dangerous {
+  --tw-border-opacity: 1;
+  border-color: rgb(225 29 72 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 63 94 / var(--tw-bg-opacity));
+}
+
+@media (prefers-color-scheme: dark) {
+  button.dangerous {
+    --tw-bg-opacity: 1;
+    background-color: rgb(190 18 60 / var(--tw-bg-opacity));
+  }
+}
+
+button {
+  --tw-border-opacity: 1;
+  border-color: rgb(22 163 74 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(34 197 94 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    --tw-bg-opacity: 1;
+    background-color: rgb(21 128 61 / var(--tw-bg-opacity));
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity));
+  }
+}
+
+button {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  border-radius: 0.75rem;
+  border-width: 1px;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   font-weight: 700;
+}
+
+button:hover {
+  --tw-brightness: brightness(1.25);
+  --tw-contrast: contrast(1.25);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+button:focus {
+  --tw-brightness: brightness(1.25);
+  --tw-contrast: contrast(1.25);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 h2 {
@@ -835,45 +897,9 @@ form {
   }
   > button,
     > form {
-    > button.edit {
-      --tw-bg-opacity: 1;
-      background-color: rgb(252 211 77 / var(--tw-bg-opacity));
-    }
-    > button.edit:hover {
-      --tw-bg-opacity: 1;
-      background-color: rgb(253 230 138 / var(--tw-bg-opacity));
-    }
-    @media (prefers-color-scheme: dark) {
-      > button.edit {
-        --tw-bg-opacity: 1;
-        background-color: rgb(245 158 11 / var(--tw-bg-opacity));
-      }
-    }
-    @media (prefers-color-scheme: dark) {
-      > button.edit:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(252 211 77 / var(--tw-bg-opacity));
-      }
-    }
-    > button.dangerous {
-      --tw-bg-opacity: 1;
-      background-color: rgb(244 63 94 / var(--tw-bg-opacity));
-    }
-    > button.dangerous:hover {
-      --tw-bg-opacity: 1;
-      background-color: rgb(253 164 175 / var(--tw-bg-opacity));
-    }
-    @media (prefers-color-scheme: dark) {
-      > button.dangerous {
-        --tw-bg-opacity: 1;
-        background-color: rgb(190 18 60 / var(--tw-bg-opacity));
-      }
-    }
-    @media (prefers-color-scheme: dark) {
-      > button.dangerous:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(244 63 94 / var(--tw-bg-opacity));
-      }
+    > button {
+      margin-left: 0px;
+      margin-right: 0px;
     }
     > button {
       border-radius: 0.375rem;
@@ -885,43 +911,6 @@ form {
     > button {
       padding-top: 0.25rem;
       padding-bottom: 0.25rem;
-    }
-    > button {
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
-      transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-      transition-duration: 150ms;
-    }
-    > button {
-      --tw-bg-opacity: 1;
-      background-color: rgb(34 197 94 / var(--tw-bg-opacity));
-    }
-    > button {
-      --tw-text-opacity: 1;
-      color: rgb(255 255 255 / var(--tw-text-opacity));
-    }
-    > button:hover {
-      --tw-bg-opacity: 1;
-      background-color: rgb(134 239 172 / var(--tw-bg-opacity));
-    }
-    @media (prefers-color-scheme: dark) {
-      > button {
-        --tw-bg-opacity: 1;
-        background-color: rgb(21 128 61 / var(--tw-bg-opacity));
-      }
-    }
-    @media (prefers-color-scheme: dark) {
-      > button {
-        --tw-text-opacity: 1;
-        color: rgb(255 255 255 / var(--tw-text-opacity));
-      }
-    }
-    @media (prefers-color-scheme: dark) {
-      > button:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(34 197 94 / var(--tw-bg-opacity));
-      }
     }
     > button {
       a {
@@ -1566,28 +1555,40 @@ table {
   }
 }
 
+.selectable-pill {
+  cursor: pointer;
+}
+
 .selectable-pill:hover {
   --tw-brightness: brightness(1.25);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .selectable-pill {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity));
   --tw-bg-opacity: 1;
   background-color: rgb(248 113 113 / var(--tw-bg-opacity));
 }
 
 .peer:checked ~ .selectable-pill {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity));
   --tw-bg-opacity: 1;
   background-color: rgb(74 222 128 / var(--tw-bg-opacity));
 }
 
 @media (prefers-color-scheme: dark) {
   .selectable-pill {
+    --tw-border-opacity: 1;
+    border-color: rgb(185 28 28 / var(--tw-border-opacity));
     --tw-bg-opacity: 1;
     background-color: rgb(153 27 27 / var(--tw-bg-opacity));
   }
 
   .peer:checked ~ .selectable-pill {
+    --tw-border-opacity: 1;
+    border-color: rgb(21 128 61 / var(--tw-border-opacity));
     --tw-bg-opacity: 1;
     background-color: rgb(22 101 52 / var(--tw-bg-opacity));
   }

--- a/main.css
+++ b/main.css
@@ -28,16 +28,33 @@
     @apply list-disc list-inside my-5;
   }
 
-  button[type="submit"],
   textarea,
   select,
   input {
     @apply rounded-xl px-6 py-2 border;
-    @apply bg-zinc-100 border-zinc-300 hover:border-amber-500 placeholder:text-slate-500;
-    @apply dark:bg-zinc-900 dark:border-zinc-700 dark:hover:border-amber-500 dark:placeholder:text-slate-500;
+    @apply bg-zinc-100 border-zinc-300 placeholder:text-slate-500;
+    @apply dark:bg-zinc-900 dark:border-zinc-700 dark:placeholder:text-slate-500;
+    @apply hover:brightness-125 hover:contrast-125;
+    @apply focus:brightness-125 focus:contrast-125;
   }
-  button[type="submit"] {
-    @apply font-bold;
+  button.edit {
+    @apply border-amber-400;
+    @apply bg-amber-300;
+    @apply dark:bg-amber-500;
+  }
+  button.dangerous {
+    @apply border-rose-600;
+    @apply bg-rose-500;
+    @apply dark:bg-rose-700;
+  }
+  button {
+    @apply border-green-600;
+    @apply text-white bg-green-500;
+    @apply dark:text-white dark:bg-green-700;
+
+    @apply rounded-xl mx-2 px-6 py-2 border font-bold;
+    @apply hover:brightness-125 hover:contrast-125;
+    @apply focus:brightness-125 focus:contrast-125;
   }
 
   h2 {
@@ -113,18 +130,8 @@
     > form {
       @apply my-0;
 
-      > button.edit {
-        @apply hover:bg-amber-200 bg-amber-300;
-        @apply dark:hover:bg-amber-300 dark:bg-amber-500;
-      }
-      > button.dangerous {
-        @apply hover:bg-rose-300 bg-rose-500;
-        @apply dark:hover:bg-rose-500 dark:bg-rose-700;
-      }
       > button {
-        @apply rounded-md px-2 py-1 transition;
-        @apply text-white hover:bg-green-300 bg-green-500;
-        @apply dark:text-white dark:hover:bg-green-500 dark:bg-green-700;
+        @apply rounded-md mx-0 px-2 py-1;
         a {
           @apply text-white hover:text-white;
           @apply dark:text-white dark:hover:text-white;
@@ -261,9 +268,10 @@
 
   .selectable-pill {
     @apply user-pill;
-    @apply hover:brightness-125;
-    @apply bg-red-400 peer-checked:bg-green-400;
-    @apply dark:bg-red-800 dark:peer-checked:bg-green-800;
+    @apply hover:brightness-125 cursor-pointer;
+
+    @apply bg-red-400  peer-checked:bg-green-400 border-red-500 peer-checked:border-red-500;
+    @apply dark:bg-red-800 dark:peer-checked:bg-green-800 dark:border-red-700 dark:peer-checked:border-green-700;
   }
 
   .user-pill {

--- a/pkg/database/profile.go
+++ b/pkg/database/profile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jovandeginste/workout-tracker/pkg/templatehelpers"
 	"gorm.io/gorm"
 )
 
@@ -66,6 +67,15 @@ func (u UserPreferredUnits) Distance() string {
 		return "mi"
 	default:
 		return "km"
+	}
+}
+
+func (u UserPreferredUnits) DistanceToDatabase(d float64) float64 {
+	switch u.Distance() {
+	case "mi":
+		return d * templatehelpers.MeterPerMile
+	default:
+		return d * templatehelpers.MeterPerKM
 	}
 }
 

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -3,7 +3,6 @@ package database
 import (
 	"crypto/sha256"
 	"errors"
-	"fmt"
 	"html/template"
 	"slices"
 	"strings"
@@ -48,6 +47,14 @@ type GPXData struct {
 	Filename  string // The filename of the file
 }
 
+func (w *Workout) HasTracks() bool {
+	if w.Data.Center.IsZero() {
+		return false
+	}
+
+	return w.Type.IsLocation()
+}
+
 func (w *Workout) Weight() float64 {
 	if w.Data == nil {
 		return 0
@@ -62,18 +69,6 @@ func (w *Workout) Repetitions() int {
 	}
 
 	return w.Data.TotalRepetitions
-}
-
-func (w *Workout) DurationString() string {
-	d := w.Duration()
-	if d == 0 {
-		return ""
-	}
-
-	h := int(d.Hours())
-	m := int(d.Minutes()) % 60
-
-	return fmt.Sprintf("%02d:%02d", h, m)
 }
 
 func (w *Workout) Duration() time.Duration {

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -85,6 +85,7 @@ type MapCenter struct {
 	Lat float64 // The latitude of the center of the workout
 	Lng float64 // The longitude of the center of the workout
 }
+
 type MapPoint struct {
 	Lat           float64       // The latitude of the point
 	Lng           float64       // The longitude of the point
@@ -178,8 +179,12 @@ func center(gpxContent *gpx.GPX) MapCenter {
 	}
 }
 
+func (m *MapCenter) IsZero() bool {
+	return m.Lat == 0 && m.Lng == 0
+}
+
 func (m *MapCenter) Address() *geo.Address {
-	if !online {
+	if !online || m.IsZero() {
 		return nil
 	}
 

--- a/pkg/database/workouts_statistics.go
+++ b/pkg/database/workouts_statistics.go
@@ -3,6 +3,8 @@ package database
 import (
 	"fmt"
 	"time"
+
+	"github.com/jovandeginste/workout-tracker/pkg/templatehelpers"
 )
 
 type BreakdownItem struct {
@@ -133,9 +135,9 @@ func (w *Workout) StatisticsPer(count float64, unit string) (WorkoutBreakdown, e
 	case "m":
 		wb.Items = w.statisticsWithUnit(count, "distance")
 	case "km":
-		wb.Items = w.statisticsWithUnit(count*1000, "distance")
+		wb.Items = w.statisticsWithUnit(count*templatehelpers.MeterPerKM, "distance")
 	case "mi":
-		wb.Items = w.statisticsWithUnit(count*1609.344, "distance")
+		wb.Items = w.statisticsWithUnit(count*templatehelpers.MeterPerMile, "distance")
 	case "sec":
 		wb.Items = w.statisticsWithUnit(count*float64(time.Second), "duration")
 	case "min":

--- a/pkg/templatehelpers/imperial.go
+++ b/pkg/templatehelpers/imperial.go
@@ -6,12 +6,13 @@ import (
 )
 
 const (
-	milesPerKM   = 0.621371192
-	feetPerMeter = 3.2808399
+	MilesPerKM   = 0.621371192
+	FeetPerMeter = 3.2808399
+	MeterPerMile = 1609.344
 )
 
 func HumanDistanceMile(d float64) string {
-	return fmt.Sprintf("%.2f", milesPerKM*d/1000)
+	return fmt.Sprintf("%.2f", MilesPerKM*d/MeterPerKM)
 }
 
 func HumanSpeedMilePH(mps float64) string {
@@ -21,7 +22,7 @@ func HumanSpeedMilePH(mps float64) string {
 
 	kmph := 3.6 * mps
 
-	return fmt.Sprintf("%.2f", milesPerKM*kmph)
+	return fmt.Sprintf("%.2f", MilesPerKM*kmph)
 }
 
 func HumanTempoMile(mps float64) string {
@@ -29,7 +30,7 @@ func HumanTempoMile(mps float64) string {
 		return InvalidValue
 	}
 
-	mpm := 1000 / (60 * mps) / milesPerKM
+	mpm := MeterPerMile / (60 * mps)
 
 	wholeMinutes := math.Floor(mpm)
 	seconds := (mpm - wholeMinutes) * 60
@@ -38,5 +39,5 @@ func HumanTempoMile(mps float64) string {
 }
 
 func HumanElevationFt(m float64) string {
-	return fmt.Sprintf("%.2f", feetPerMeter*m)
+	return fmt.Sprintf("%.2f", FeetPerMeter*m)
 }

--- a/pkg/templatehelpers/metric.go
+++ b/pkg/templatehelpers/metric.go
@@ -5,8 +5,10 @@ import (
 	"math"
 )
 
+const MeterPerKM = 1000
+
 func HumanDistanceKM(d float64) string {
-	return fmt.Sprintf("%.2f", d/1000)
+	return fmt.Sprintf("%.2f", d/MeterPerKM)
 }
 
 func HumanSpeedKPH(mps float64) string {
@@ -24,7 +26,7 @@ func HumanTempoKM(mps float64) string {
 		return InvalidValue
 	}
 
-	mpk := 1000 / (60 * mps)
+	mpk := MeterPerKM / (60 * mps)
 
 	wholeMinutes := math.Floor(mpk)
 	seconds := (mpk - wholeMinutes) * 60

--- a/views/partials/workout_map.html
+++ b/views/partials/workout_map.html
@@ -1,0 +1,29 @@
+{{ define "workout_map" }}
+<div
+  id="map"
+  class="border-2 border-black rounded-xl h-[300px] sm:h-[400px] md:h-[600px] print:w-full print:h-[600px]"
+>
+  <script src="{{ RouteFor `assets` }}/map.js"></script>
+  <script>
+    makeMap({
+      elementID: "map",
+      center: [{{ .Data.Center.Lat  }}, {{  .Data.Center.Lng  }}],
+      minElevation: {{ .Data.MinElevation }},
+      maxElevation: {{ .Data.MaxElevation }},
+      maxSpeed: {{ .Data.MaxSpeed }},
+      speedName: "{{ i18n "Average speed" }}",
+      elevationName: "{{ i18n "Elevation" }}",
+
+      points: [
+        {{ with .Data.Details }}
+        {{ range .Points -}}
+        { "lat": {{ .Lat }}, "lng": {{ .Lng }}, "speed": {{ .AverageSpeed }}, "elevation": {{ .ExtraMetrics.Get "elevation" }}, "title": "{{ template `workout_point_title` . }}", },
+        {{ end  }}
+        {{ end  }}
+      ]
+    });
+  </script>
+</div>
+{{ if and (not AppConfig.SocialsDisabled) (not
+CurrentUser.Profile.SocialsDisabled) }} {{ template "workout_social" .}} {{ end
+}} {{ end }}

--- a/views/partials/workouts_list_details.html
+++ b/views/partials/workouts_list_details.html
@@ -30,19 +30,6 @@
     {{ .Data.AverageSpeedNoPause | HumanSpeed }} {{
     CurrentUser.PreferredUnits.Speed }}
   </div>
-  <div
-    class="hidden 2xl:table-cell whitespace-nowrap font-mono {{ IconFor `speed` }}"
-    title="{{ i18n `Average speed (no pause)` }}"
-  >
-    {{ .Data.AverageSpeedNoPause | HumanTempo }} {{
-    CurrentUser.PreferredUnits.Tempo }}
-  </div>
-  <div
-    class="hidden 2xl:table-cell whitespace-nowrap font-mono {{ IconFor `max-speed` }}"
-    title="{{ i18n `Max speed` }}"
-  >
-    {{ .Data.MaxSpeed | HumanSpeed }} {{ CurrentUser.PreferredUnits.Speed }}
-  </div>
   {{ end }} {{ if .Type.IsWeight }}
   <div
     class="hidden sm:table-cell whitespace-nowrap font-mono {{ IconFor `weight` }}"

--- a/views/workouts/workout_form.html
+++ b/views/workouts/workout_form.html
@@ -45,13 +45,36 @@
   <td><label for="duration">{{ i18n "Duration" }}</label></td>
   <td>
     <input
-      type="time"
-      name="duration"
-      id="duration"
-      value="{{ .DurationString }}"
+      type="number"
+      name="duration_hours"
+      id="duration_hours"
+      min="0"
+      max="999"
+      maxlength="3"
+      value="{{ int .Duration.Hours }}"
+      required
+    />:
+    <input
+      type="number"
+      name="duration_minutes"
+      id="duration_minutes"
+      min="0"
+      max="59"
+      maxlength="2"
+      value="{{ mod .Duration.Minutes 60 }}"
+      required
+    />:
+    <input
+      type="number"
+      name="duration_seconds"
+      id="duration_seconds"
+      min="0"
+      max="59"
+      maxlength="2"
+      value="{{ mod .Duration.Seconds 60 }}"
       required
     />
-    (hh:mm)
+    (hhh:mm:ss)
   </td>
 </tr>
 {{ end }} {{ if .Type.IsDistance }}
@@ -59,7 +82,7 @@
   <td><label for="distance">{{ i18n "Distance" }}</label></td>
   <td>
     <input
-      type="number"
+      type="text"
       name="distance"
       id="distance"
       value="{{ default `` (.Distance | HumanDistance) }}"
@@ -86,7 +109,7 @@
   <td><label for="weight">{{ i18n "Weight" }}</label></td>
   <td>
     <input
-      type="number"
+      type="text"
       name="weight"
       id="weight"
       value="{{ default `` .Weight }}"
@@ -101,7 +124,7 @@
     <label for="notes">{{ i18n "Notes" }}</label>
   </td>
   <td>
-    <textarea type="text" id="notes" name="notes" rows="10">
+    <textarea type="text" id="notes" name="notes" rows="10" cols="60">
 {{ .Notes }}</textarea
     >
   </td>

--- a/views/workouts/workouts_edit.html
+++ b/views/workouts/workouts_edit.html
@@ -52,6 +52,16 @@
                     <td></td>
                     <td>
                       <button type="submit">{{ i18n "Update workout" }}</button>
+                      <button type="reset" class="edit">
+                        {{ i18n "Reset changes" }}
+                      </button>
+                      <button
+                        type="button"
+                        class="dangerous"
+                        onclick="document.location='{{ RouteFor `workout-show` .ID }}'"
+                      >
+                        {{ i18n "Cancel" }}
+                      </button>
                     </td>
                   </tr>
                 </tfoot>
@@ -63,12 +73,7 @@
           <div class="inner-form">{{ template "workout_details" . }}</div>
         </div>
       </div>
-      {{ if .Notes }}
-      <div class="inner-form">
-        <h3 class="{{ IconFor `note` }}">{{ i18n "Notes" }}</h3>
-        <div>{{ .Notes }}</div>
-      </div>
-      {{ end }} {{ end }}
+      {{ end }}
     </div>
 
     {{ template "footer" . }}

--- a/views/workouts/workouts_show.html
+++ b/views/workouts/workouts_show.html
@@ -32,38 +32,9 @@
         </h2>
       </div>
       <div class="lg:flex lg:flex-wrap print:block">
+        {{ if .HasTracks }}
         <div class="basis-1/2 2xl:basis-1/3 pagebreak">
-          {{ if .Type.IsLocation }}
-          <div class="inner-form">
-            <div
-              id="map"
-              class="border-2 border-black rounded-xl h-[300px] sm:h-[400px] md:h-[600px] print:w-full print:h-[600px]"
-            >
-              <script src="{{ RouteFor `assets` }}/map.js"></script>
-              <script>
-                makeMap({
-                  elementID: "map",
-                  center: [{{ .Data.Center.Lat  }}, {{  .Data.Center.Lng  }}],
-                  minElevation: {{ .Data.MinElevation }},
-                  maxElevation: {{ .Data.MaxElevation }},
-                  maxSpeed: {{ .Data.MaxSpeed }},
-                  speedName: "{{ i18n "Average speed" }}",
-                  elevationName: "{{ i18n "Elevation" }}",
-
-                  points: [
-                    {{ with .Data.Details }}
-                    {{ range .Points -}}
-                    { "lat": {{ .Lat }}, "lng": {{ .Lng }}, "speed": {{ .AverageSpeed }}, "elevation": {{ .ExtraMetrics.Get "elevation" }}, "title": "{{ template `workout_point_title` . }}", },
-                    {{ end  }}
-                    {{ end  }}
-                  ]
-                });
-              </script>
-            </div>
-            {{ if and (not AppConfig.SocialsDisabled) (not
-            CurrentUser.Profile.SocialsDisabled) }} {{ template "workout_social"
-            .}} {{ end }}
-          </div>
+          <div class="inner-form">{{ template "workout_map" . }}</div>
         </div>
         {{ end }}
         <div class="basis-1/2 2xl:basis-1/3">


### PR DESCRIPTION
In order to correctly support Imperial units and locales, we:
- change the input field for duration into split fields for hours,
  minutes and seconds (bonus: we now allow seconds)
- correctly convert the input distance from the user's preferred unit
  - for this, we add and use more constants

There's now a new reset button on the edit form that resets the input
fields back to their initial values, and a close button to go back to
the view.

We no longer show a few workout details in the list view:
- average speed without pauze
- max speed

We update the workout view page, to hide the map if there is no map to
show (even if it's a location-based workout). This is currently
determined by checking if the map center is "0, 0".

We also update the cosmetic layout of the buttons, to be more consistent
and intuitive.

Fixes: #217

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>