### PR TITLE
fix: calculate rate limit time remaining

### DIFF
--- a/pkg/geocoder/reverse.go
+++ b/pkg/geocoder/reverse.go
@@ -98,8 +98,8 @@ func (c *client) wait() {
 		return
 	}
 
-	d := time.Since(c.lastRequest) - requestInterval
-	if d > 0 {
+	d := requestInterval - time.Since(c.lastRequest)
+	if d < 0 {
 		return
 	}
 


### PR DESCRIPTION
The logic was inversed accidentally. This is now corrected.