### PR TITLE
refactor: improve API button style and behavior

### DIFF
--- a/views/user/user_profile.html
+++ b/views/user/user_profile.html
@@ -53,17 +53,19 @@
                     action="{{ RouteFor `user-profile-reset-api-key` }}"
                   >
                     <button
-                      class="{{ IconFor `show` }}"
+                      type="button"
+                      class="{{ IconFor `show` }} edit"
                       title="{{ i18n `show/hide` }}"
-                      onclick="toggleTextPassword(this, 'api_key'); return false;"
+                      onclick="toggleTextPassword(this, 'api_key');"
                     />
                     <button
+                      type="button"
                       class="{{ IconFor `copy` }}"
                       title="{{ i18n `copy to clipboard` }}"
-                      onclick="copyToClipboard('api_key'); return false;"
+                      onclick="copyToClipboard('api_key');"
                     />
                     <button
-                      class="{{ IconFor `refresh` }}"
+                      class="{{ IconFor `refresh` }} dangerous"
                       title="{{ i18n `generate a new API key` }}"
                     />
                   </form>


### PR DESCRIPTION
By setting the button's types to "button", the `return false;` is no longer needed.