### PR TITLE
feat: refactor workouts handlers to use HasFile method instead of nil…

### DIFF
--- a/pkg/app/workouts_handlers.go
+++ b/pkg/app/workouts_handlers.go
@@ -117,9 +117,7 @@ func (a *App) workoutsDownloadHandler(c echo.Context) error {
 		return a.redirectWithError(c, "/workouts", err)
 	}
 
-	if workout.GPX == nil ||
-		workout.GPX.Filename == "" ||
-		workout.GPX.Content == nil {
+	if !workout.HasFile() {
 		return a.redirectWithError(c, "/workouts", errors.New("workout has no content"))
 	}
 

--- a/views/partials/workout_actions.html
+++ b/views/partials/workout_actions.html
@@ -1,19 +1,22 @@
-{{ define "workout_actions" }}
+{{ define "workout_actions" }} {{ if .HasFile }}
 <form action="{{ RouteFor `workout-download` .ID }}" method="get">
   <button class="download" title="{{ i18n `download` }}">
     <a class="{{ IconFor `download` }}"></a>
   </button>
 </form>
+{{ end }}
 <form action="{{ RouteFor `workout-edit` .ID }}" method="get">
   <button class="edit" title="{{ i18n `edit` }}">
     <a class="{{ IconFor `edit` }}"></a>
   </button>
 </form>
+{{ if .HasFile }}
 <form action="{{ RouteFor `workout-refresh` .ID }}" method="post">
   <button title="{{ i18n `refresh` }}">
     <a class="{{ IconFor `refresh` }}"></a>
   </button>
 </form>
+{{ end }}
 <form onsubmit="return false">
   <button
     onclick="openModal('modalConfirmDelete_{{ .ID }}')"


### PR DESCRIPTION
… checks

- Changed the `workouts_handlers.go` file to use the `HasFile` method introduced in `database/workouts.go` instead of manual nil checks.
- Updated the `GetWorkoutDetails` function in `database/workouts.go` to use `GetWorkoutWithGPX` instead of `GetWorkout`.
- Updated the `AsGPX`, `UpdateData`, and `HasExtraMetric` methods in `database/workouts.go` to use the `HasFile` method.
- Added a check for `HasFile` in the workout actions partial template (`views/partials/workout_actions.html`) to conditionally display the download, refresh, and edit forms.