### PR TITLE
fix: add function to get filename of workout

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -41,6 +41,14 @@ type GPXData struct {
 	Filename  string // The filename of the file
 }
 
+func (w *Workout) Filename() string {
+	if !w.HasFile() {
+		return w.Name + ".txt"
+	}
+
+	return w.GPX.Filename
+}
+
 func (w *Workout) HasFile() bool {
 	if w.GPX == nil {
 		return false

--- a/views/workouts/workouts_edit.html
+++ b/views/workouts/workouts_edit.html
@@ -9,7 +9,9 @@
       {{ with .workout }}
       <div class="gap-4">
         <h2 class="{{ IconFor .Type.String }}">
-          {{ .Name }} {{ with .Filename }}({{ . }}){{ end }}
+          {{ .Name }} {{ if .HasFile }}(<span class="{{ IconFor `file` }}"
+            >{{ .Filename }}</span
+          >) {{ end }}
         </h2>
       </div>
       <div class="sm:flex sm:flex-wrap">

--- a/views/workouts/workouts_show.html
+++ b/views/workouts/workouts_show.html
@@ -28,7 +28,9 @@
         {{ end }}
 
         <h2 class="{{ IconFor .Type.String }}">
-          {{ .Name }} {{ with .Filename }}({{ . }}){{ end }}
+          {{ .Name }} {{ if .HasFile }}(<span class="{{ IconFor `file` }}"
+            >{{ .Filename }}</span
+          >) {{ end }}
         </h2>
       </div>
       <div class="lg:flex lg:flex-wrap print:block">


### PR DESCRIPTION
There was a key that stored the filename of a workout, which was no longer used and therefore removed in the previous PR (#232). This broke the code for viewing and editing a workout, which still referenced the old key.

We fix this by adding a function, that dynamically generates a new filename if there was none, and checking whether we have data in the views.