### PR TITLE
fix: add prettier and air dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ THEME_SCREENSHOT_HEIGHT ?= 900
 all: clean install-deps test build
 
 install-deps:
+	go install github.com/air-verse/air@latest
 	npm install
 
 clean:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.17",
+        "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1"
       }
     },
@@ -1609,6 +1610,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-hrtime": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "autoprefixer": "^10.4.17",
+    "prettier": "^3.3.3",
     "tailwindcss": "^3.4.1"
   },
   "dependencies": {


### PR DESCRIPTION
Prettier and air were missing on my system, so `make dev` and `make build-all` would not work. This adds prettier as 'dev dependency' in package.json and adds a command to install air in the `install-deps' target of the Makefile.