### PR TITLE
fix: do not show zero heart rate in chart

### DIFF
--- a/views/partials/workout_show_stats.html
+++ b/views/partials/workout_show_stats.html
@@ -74,7 +74,10 @@
           {{ range .Items -}}
           { "x": {{ .FirstPoint.Time }}, "y": {{ .FirstPoint.ExtraMetrics.Get "heart-rate" }}, },
           {{- end  }}
-        ],
+        ].map((p) => {
+          if(p.y <= 0) p.y = null;
+          return p;
+        }),
       },
       {
         name: "{{ i18n `Cadence` }}",


### PR DESCRIPTION
This replaces y=0 with y=null for chart points in the series for 'heart rate'. 

Zero heart rates don't really make senes (but sometimes happen when i.e. the heart rate sensor hasn't measured anything yet). The zero points do however mess up the Y axis scale.

Before: 

![image](https://github.com/user-attachments/assets/8a7b900e-556a-456c-b4b9-88b4c6ff7636)


After:

![image](https://github.com/user-attachments/assets/824d61e5-ff4b-42d5-9bed-fce4958e0edb)
