### PR TITLE
feat: Add donation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,30 @@ Self-hosted, everything included.
 
 Heavily inspired by [FitTrackee](https://github.com/SamR1/FitTrackee) :heart:.
 
+## :heart: Donate your workout files :heart:
+
+We are collecting real workout files for testing purposes. If you want to
+support the project, donate your files. You can open an issue and attach the
+file, or send a pull request.
+
+We are looking for general files from all sources, but also "raw" files from
+devices. The first file type can be edited to remove personal information, but
+the second type should be as pure (raw) as possible.
+
+Make sure the file does not contain personally identifiable information,
+specifically your home address! Preferably, share files from workouts that you
+recorded while travelling.
+
+Be sure to add some metadata in the issue or pull request, such as:
+
+- the activity type (running, swimming, ...)
+- the general location's name (city, national park, ...)
+- anything relevant, such as whether there is heart rate or cadence data, or any
+  other data
+
+By donating the files, you grant the project full permission to use them as they
+see fit.
+
 ## Getting started
 
 ### Docker


### PR DESCRIPTION
This change adds a section to the README that asks users to donate workout files for testing purposes. The section encourages users to contribute to the project by sharing their files, which will help the developers improve the accuracy and functionality of the software. The section also includes guidelines for sharing files and ensures users understand the project's usage of donated files.