### PR TITLE
feat: Add calorie calculation and display

### DIFF
--- a/assets/output.css
+++ b/assets/output.css
@@ -2713,6 +2713,14 @@ table {
   content: "\f15b";
 }
 
+.icon-fire::before {
+  content: "\f06d";
+}
+
+.icon-fire::after {
+  content: "\f06d";
+}
+
 .icon-gauge::before {
   content: "\f624";
 }

--- a/pkg/app/templates.go
+++ b/pkg/app/templates.go
@@ -87,6 +87,7 @@ func (a *App) viewTemplateFunctions() template.FuncMap {
 		"HumanDistance":  templatehelpers.HumanDistanceKM,
 		"HumanSpeed":     templatehelpers.HumanSpeedKPH,
 		"HumanTempo":     templatehelpers.HumanTempoKM,
+		"HumanCalories":  templatehelpers.HumanCaloriesKcal,
 
 		"RelativeDate": h.NaturalTime,
 

--- a/pkg/database/workout_met.go
+++ b/pkg/database/workout_met.go
@@ -1,0 +1,122 @@
+package database
+
+// Information from:
+// - https://media.hypersites.com/clients/1235/filemanager/MHC/METs.pdf
+// - https://cdn-links.lww.com/permalink/mss/a/mss_43_8_2011_06_13_ainsworth_202093_sdc1.pdf
+
+// metabolic equivalent of task
+func (w *Workout) MET() float64 {
+	switch {
+	case w.Type.IsDistance():
+		return w.distanceMET()
+	case w.Type.IsRepetition():
+		return w.repititionMET()
+	default:
+		return 1
+	}
+}
+
+// | Activity                        | Speed (km/h) | Speed (m/s) | METs |
+// |---------------------------------|--------------|-------------|------|
+// | Walking, slowly (stroll)        | -            | -           | 2.0  |
+// | Walking, 2 mph                  | 3.2          | 0.89        | 2.5  |
+// | Walking, 3 mph (20 min/mile)    | 4.8          | 1.34        | 3.3  |
+// | Walking, 17 min/mile            | 5.6          | 1.56        | 3.8  |
+// | Walking, 15 min/mile            | 6.4          | 1.79        | 5.0  |
+// | Race walking, moderate pace     | -            | -           | 6.5  |
+// | Hiking up hills                 | -            | -           | 6.9  |
+// | Hiking hills, 12 lb pack        | -            | -           | 7.5  |
+// | Jogging, 12 min/mile            | 8.0          | 2.23        | 8.0  |
+// | Running, 10 min/mile            | 9.7          | 2.68        | 10.0 |
+// | Running, 9 min/mile             | 10.8         | 3.01        | 11.0 |
+// | Running, 8 min/mile             | 12.1         | 3.36        | 12.5 |
+// | Running, 7 min/mile             | 13.8         | 3.85        | 14.0 |
+// | Running, 6 min/mile             | 16.1         | 4.47        | 16.0 |
+
+func (w *Workout) distanceOnFootMET() float64 {
+	s := w.Data.AverageSpeedNoPause() // meters per second
+
+	switch {
+	case s < 0.89:
+		return 2.0
+	case s < 1.34:
+		return 2.5
+	case s < 1.56:
+		return 3.3
+	case s < 1.79:
+		return 3.8
+	case s < 1.90:
+		return 5.0
+	case s < 2.10:
+		return 6.5
+	case s < 2.23:
+		return 6.5
+	case s < 2.68:
+		return 8.0
+	case s < 3.01:
+		return 10.0
+	case s < 3.36:
+		return 11.0
+	case s < 3.85:
+		return 12.5
+	case s < 4.47:
+		return 14.0
+	default:
+		return 16.0
+	}
+}
+
+// | Activity                         | Speed (km/h) | Speed (m/s) | METs |
+// |----------------------------------|--------------|-------------|------|
+// | Stationary cycling, 50 watts     | -            | -           | 3.0  |
+// | Bicycling, leisurely             | -            | -           | 3.5  |
+// | Stationary cycling, 100 watts    | -            | -           | 5.5  |
+// | Bicycling, 12-13 mph             | 19.3         | 5.36        | 8.0  |
+// | Bicycling, 14-15 mph             | 23.3         | 6.47        | 10.0 |
+// | Bicycling, 16-19 mph             | 28.9         | 8.03        | 12.0 |
+// | Bicycling, 20+ mph               | 32.2+        | 8.94+       | 16.0 |
+
+func (w *Workout) distanceCyclingMET() float64 {
+	s := w.Data.AverageSpeedNoPause() // meters per second
+
+	switch {
+	case s < 3.0:
+		return 3.0
+	case s < 4.0:
+		return 3.5
+	case s < 5.36:
+		return 5.5
+	case s < 6.47:
+		return 8.0
+	case s < 8.03:
+		return 10.0
+	case s < 8.94:
+		return 12.0
+	default:
+		return 16.0
+	}
+}
+
+func (w *Workout) distanceMET() float64 {
+	switch w.Type { //nolint:exhaustive
+	case WorkoutTypeWalking, WorkoutTypeHiking, WorkoutTypeRunning:
+		return w.distanceOnFootMET()
+	case WorkoutTypeCycling:
+		return w.distanceCyclingMET()
+	default:
+		return 3.5
+	}
+}
+
+func (w *Workout) repititionMET() float64 {
+	freq := w.RepetitionFrequencyPerMinute()
+
+	switch {
+	case freq < 5:
+		return 3.5
+	case freq < 10:
+		return 5
+	default:
+		return 8.0
+	}
+}

--- a/pkg/database/workout_type.go
+++ b/pkg/database/workout_type.go
@@ -128,7 +128,7 @@ func LocationWorkoutTypes() []WorkoutType {
 
 func DurationWorkoutTypes() []WorkoutType {
 	return getOrSetByClass(WorkoutTypeClassDuration, func(c WorkoutTypeConfiguration) bool {
-		return true
+		return true // All workout types store duration
 	})
 }
 

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -381,6 +381,30 @@ func (w *Workout) UpdateRouteSegmentMatches(db *gorm.DB) error {
 	return nil
 }
 
+func (w *Workout) RepetitionFrequencyPerMinute() float64 {
+	if w.Data == nil {
+		return 0
+	}
+
+	return float64(w.Data.TotalRepetitions) / w.Duration().Minutes()
+}
+
+func (w *Workout) HasCalories() bool {
+	return w.Type.IsDuration()
+}
+
+func (w *Workout) CaloriesBurned() float64 {
+	if !w.Type.IsDuration() {
+		return 0
+	}
+
+	weight := 70.0 // assume weight is 70 kg for now
+	// Calories burned = weight * time * intensity (MET)
+	cb := weight * w.Duration().Hours() * w.MET()
+
+	return cb
+}
+
 func (w *Workout) HasElevation() bool {
 	return w.HasExtraMetric("elevation")
 }

--- a/pkg/templatehelpers/icons.go
+++ b/pkg/templatehelpers/icons.go
@@ -54,6 +54,8 @@ func categoryIcon(what string) string {
 		return iconDefaults + " icon-regular icon-calendar"
 	case "pause":
 		return iconDefaults + " icon-regular icon-hourglass"
+	case "calories":
+		return iconDefaults + " icon-solid icon-fire"
 	default:
 		return ""
 	}
@@ -142,7 +144,7 @@ func pageIcon(what string) string {
 	}
 }
 
-func utilityIcon(what string) string { //nolint:gocyclo
+func utilityIcon(what string) string {
 	switch what {
 	case "close":
 		return iconDefaults + " icon-solid icon-xmark"

--- a/pkg/templatehelpers/template_funcs.go
+++ b/pkg/templatehelpers/template_funcs.go
@@ -1,6 +1,7 @@
 package templatehelpers
 
 import (
+	"fmt"
 	"html/template"
 	"strings"
 	"time"
@@ -13,6 +14,10 @@ import (
 var englishTag = display.English.Languages()
 
 const InvalidValue = "N/A"
+
+func HumanCaloriesKcal(cal float64) string {
+	return fmt.Sprintf("%.2f kcal", cal)
+}
 
 func NumericDuration(d time.Duration) float64 {
 	return d.Seconds()

--- a/views/partials/workout_details.html
+++ b/views/partials/workout_details.html
@@ -40,6 +40,13 @@
       <th>{{ i18n "Repetitions" }}</th>
       <td class="whitespace-nowrap font-mono">{{ .Data.TotalRepetitions }}</td>
     </tr>
+    <tr>
+      <td class="{{ IconFor `tempo` }}"></td>
+      <th>{{ i18n "Average per minute" }}</th>
+      <td class="whitespace-nowrap font-mono">
+        {{ .RepetitionFrequencyPerMinute }}
+      </td>
+    </tr>
     {{ end }}{{ if .Type.IsWeight }}
     <tr>
       <td class="{{ IconFor `weight` }}"></td>
@@ -141,6 +148,23 @@
       <td class="whitespace-nowrap font-mono">
         {{ .Data.TotalDown | HumanElevation }} {{
         CurrentUser.PreferredUnits.Elevation }}
+      </td>
+    </tr>
+    {{ end }} {{ if .HasCalories }}
+    <tr>
+      <td class="{{ IconFor `calories` }}"></td>
+      <th>
+        {{ i18n "Est. calories burned" }}
+        <a
+          class="{{ IconFor `info` }}"
+          href="#"
+          title="{{ i18n `Estimated based on the activity, assuming 70 kg` }}"
+        >
+          &nbsp;
+        </a>
+      </th>
+      <td class="whitespace-nowrap font-mono">
+        {{ .CaloriesBurned | HumanCalories }}
       </td>
     </tr>
     {{ end }}

--- a/views/user/user_profile.html
+++ b/views/user/user_profile.html
@@ -22,8 +22,9 @@
                       title="{{ i18n `how to use` }}"
                       target="_blank"
                       href="https://github.com/jovandeginste/workout-tracker?tab=readme-ov-file#api-usage"
-                      >&nbsp;</a
                     >
+                      &nbsp;
+                    </a>
                   </label>
                 </th>
                 <td class="flex flex-wrap gap-5">


### PR DESCRIPTION
Adds calorie burned calculation and display on workout details page. The calories are estimated based on the activity, assuming a weight of 70 kg. This gives the user a rough idea of how many calories they burned during the workout. Also adds repetition frequency per minute display on workout details page. This is useful for understanding the intensity of a repetition-based workout.

Fixes #260