### PR TITLE
add golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # 6.0.1
         with:
           version: latest
-          only-new-issues: false
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,27 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Test golangci-lint for go-version define in go.mod
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # 6.0.1
+        with:
+          version: latest
+          only-new-issues: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - dupword # Detects duplicate words.
     - durationcheck
     - errchkjson
-    - exportloopref # Detects pointers to enclosing loop variables.
+    - copyloopvar # Detects pointers to enclosing loop variables.
     - gocritic # Metalinter; detects bugs, performance, and styling issues.
     - gocyclo
     - gofumpt # Detects whether code was gofumpt-ed.

--- a/pkg/database/workout_met.go
+++ b/pkg/database/workout_met.go
@@ -4,7 +4,7 @@ package database
 // - https://media.hypersites.com/clients/1235/filemanager/MHC/METs.pdf
 // - https://cdn-links.lww.com/permalink/mss/a/mss_43_8_2011_06_13_ainsworth_202093_sdc1.pdf
 
-// metabolic equivalent of task
+// MET returns the metabolic equivalent of task
 func (w *Workout) MET() float64 {
 	switch {
 	case w.Type.IsDistance():


### PR DESCRIPTION
this PR try to add golangci-lint so we don't merge code that not pass golangci-lint rull.
Note: *currently make test-go run golangci-lint that fails but it is not show in CI so potential merge code that not pass (that happen right now)*