### PR TITLE
fix: show min/mi value instead of min/km when using imperial units

### DIFF
--- a/pkg/templatehelpers/template_funcs.go
+++ b/pkg/templatehelpers/template_funcs.go
@@ -56,7 +56,7 @@ func HumanSpeedFor(unit string) func(float64) string {
 
 func HumanTempoFor(unit string) func(float64) string {
 	switch unit {
-	case "mi":
+	case "min/mi", "mi":
 		return HumanTempoMile
 	default:
 		return HumanTempoKM


### PR DESCRIPTION
Fixes: #294