### PR TITLE
feat: Show elevation of route segment instead of speed

### DIFF
--- a/assets/map.js
+++ b/assets/map.js
@@ -83,6 +83,7 @@ function makeMap(params) {
     const speedLayerGroup = new L.featureGroup();
     const elevationLayerGroup = new L.featureGroup();
 
+    var hasSpeed = false;
     params.points.forEach((pt) => {
       p = [pt.lat, pt.lng];
 
@@ -111,6 +112,7 @@ function makeMap(params) {
         if (pt.speed === null || pt.speed < 0.1) {
           polyLineProperties["color"] = "rgb(0,0,0)"; // Pausing
         } else {
+          hasSpeed = true;
           if (movingSpeeds.length > MOVING_AVERAGE_LENGTH) {
             movingSpeeds.shift();
           }
@@ -128,8 +130,11 @@ function makeMap(params) {
       prevPoint = p;
     });
 
-    // elevationLayerGroup.addTo(map);
-    speedLayerGroup.addTo(map);
+    if (!hasSpeed || params.showElevation) {
+      elevationLayerGroup.addTo(map);
+    } else {
+      speedLayerGroup.addTo(map);
+    }
 
     var last = params.points[params.points.length - 1];
     group.addLayer(

--- a/views/partials/route_segment_map.html
+++ b/views/partials/route_segment_map.html
@@ -14,6 +14,7 @@
       elevationName: "{{ i18n "Elevation" }}",
       streetsName: "{{ i18n "Streets" }}",
       aerialName: "{{ i18n "Aerial" }}",
+      showElevation: true,
 
       points: [
         {{ range .Points -}}


### PR DESCRIPTION
When the track does not have any speed data, the elevation view is shown by default. An option has been added to the interface to manually toggle between elevation and speed view, which is used for route segments.