### PR TITLE
fix: Use default file name "workout.gpx"

### DIFF
--- a/pkg/importers/generic.go
+++ b/pkg/importers/generic.go
@@ -8,7 +8,7 @@ import (
 )
 
 func importGeneric(c echo.Context, body io.ReadCloser) (*Content, error) {
-	name := cmp.Or(c.QueryParam("name"), "no-name")
+	name := cmp.Or(c.QueryParam("name"), "workout.gpx")
 	t := cmp.Or(c.QueryParam("type"), "auto")
 
 	b, err := io.ReadAll(body)


### PR DESCRIPTION
The type of workout is inferred from the file's extension; by adding `.gpx`, the importer knows how to parse it.

Fixes #307