### PR TITLE
fix(importer): Remove Filename field reset

### DIFF
--- a/pkg/importers/fitotrack.go
+++ b/pkg/importers/fitotrack.go
@@ -24,7 +24,6 @@ func importFitotrack(c echo.Context, body io.ReadCloser) (*Content, error) {
 
 	b.Type = wt
 	b.Notes = wn
-	b.Filename = ""
 
 	return b, nil
 }


### PR DESCRIPTION
The `Filename` field was set to an empty string, which is not needed and can be removed. This confused the importer, since it uses the filename to assess which type of file it gets

Fixes #307 (again)