### PR TITLE
Style(css): Remove unused material icons link

### DIFF
--- a/views/partials/head.html
+++ b/views/partials/head.html
@@ -3,10 +3,6 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="icon" type="image/png" href="{{ RouteFor `assets` }}/dumbbell.png" />
-<link
-  href="{{ RouteFor `assets` }}/dist/material-icons/css/all.css"
-  rel="stylesheet"
-/>
 <link href="{{ RouteFor `assets` }}/output.css" rel="stylesheet" />
 <script src="{{ RouteFor `assets` }}/common.js"></script>
 <script src="{{ RouteFor `assets` }}/dist/htmx.min.js"></script>


### PR DESCRIPTION
The material icons CSS file was no longer being used in the application.