### PR TITLE
feat(style): Add cursor pointer style and apply to filter summary

### DIFF
--- a/assets/output.css
+++ b/assets/output.css
@@ -2829,6 +2829,10 @@ table {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
+.cursor-pointer {
+  cursor: pointer;
+}
+
 .resize {
   resize: both;
 }

--- a/views/workouts/workouts_list.html
+++ b/views/workouts/workouts_list.html
@@ -17,7 +17,7 @@
         </div>
       </div>
       <details class="inner-form" {{ if .Filters.Active }}open{{ end }}>
-        <summary>Filter workouts</summary>
+        <summary class="cursor-pointer">Filter workouts</summary>
         {{ $filters := .Filters }}
         <form id="filters" method="get" action="{{ RouteFor `workouts` }}">
           <input type="hidden" id="active" name="active" value="true" />


### PR DESCRIPTION
Added a `.cursor-pointer` class to style the cursor as a pointer when hovering over elements. This improves the user experience by providing clearer visual feedback that an element is interactive. Applied this class to the filter summary in `workouts_list.html` to make it clear that the summary is clickable.