### PR TITLE
refactor(converters): Improve name detection

### DIFF
--- a/pkg/converters/parse.go
+++ b/pkg/converters/parse.go
@@ -16,6 +16,23 @@ func Parse(filename string, content []byte) (*gpx.GPX, error) {
 		return ParseGPX(content)
 	}
 
+	basename := path.Base(filename)
+
+	c, err := parseContent(basename, content)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Name != "" || len(c.Tracks) > 0 {
+		return c, nil
+	}
+
+	c.Name = basename
+
+	return c, nil
+}
+
+func parseContent(filename string, content []byte) (*gpx.GPX, error) {
 	suffix := path.Ext(filename)
 
 	switch suffix {

--- a/pkg/database/gpx_sample_1_test.go
+++ b/pkg/database/gpx_sample_1_test.go
@@ -14,7 +14,7 @@ const GpxSample1 = `<?xml version="1.0" encoding="UTF-8"?>
     <time>2012-10-24T23:22:51.000Z</time>
   </metadata>
   <trk>
-    <name>Untitled</name>
+    <name>Some name</name>
     <trkseg>
       <trkpt lon="-77.02016168273985" lat="38.92747367732227">
         <ele>25.600000381469727</ele>

--- a/pkg/database/workouts_test.go
+++ b/pkg/database/workouts_test.go
@@ -64,7 +64,7 @@ func TestWorkout_Parse(t *testing.T) {
 	assert.InDelta(t, 3125, w.Data.TotalDistance, 1)
 	assert.InDelta(t, 3.297, w.Data.AverageSpeed, 0.01)
 	assert.InDelta(t, 3.297, w.Data.AverageSpeedNoPause, 0.01)
-	assert.Equal(t, "Untitled", w.Name)
+	assert.Equal(t, "Some name", w.Name)
 	assert.Nil(t, w.Data.Address)
 }
 


### PR DESCRIPTION
Some workout files don't have a name; in that case, we use the filename as the name of the workout.