### PR TITLE
Fix(gpx): Handle GPX files without track names

### DIFF
--- a/pkg/converters/parse.go
+++ b/pkg/converters/parse.go
@@ -23,7 +23,11 @@ func Parse(filename string, content []byte) (*gpx.GPX, error) {
 		return nil, err
 	}
 
-	if c.Name != "" || len(c.Tracks) > 0 {
+	if c.Name != "" {
+		return c, nil
+	}
+
+	if len(c.Tracks) > 0 && c.Tracks[0].Name != "" {
 		return c, nil
 	}
 


### PR DESCRIPTION
The previous implementation incorrectly assumed that GPX files with tracks had names. This commit modifies the parsing logic to correctly handle such files by checking whether the first track has a name or not