### PR TITLE
feat(database): Improve statistics query

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,13 +1,23 @@
 [build]
-  bin               = "./tmp/workout-tracker"
-  cmd               = "make build-server"
-  delay             = 1000
-  exclude_dir       = ["docs", "testdata", "tmp", "vendor"]
-  exclude_file      = ["assets/output.css", "screenshots.js"]
-  exclude_regex     = ["_templ.go", "_test.go"]
+  bin = "./tmp/workout-tracker"
+  cmd = "make build-server"
+  delay = 1000
+  exclude_dir = ["docs", "testdata", "tmp", "vendor"]
+  exclude_file = ["assets/output.css", "screenshots.js"]
+  exclude_regex = ["_templ.go", "_test.go"]
   exclude_unchanged = false
-  include_ext       = ["css", "go", "html", "js", "json", "templ", "tmpl", "tpl"]
-  stop_on_error     = true
+  include_ext = [
+    "css",
+    "go",
+    "html",
+    "js",
+    "json",
+    "templ",
+    "tmpl",
+    "tpl",
+    "yaml",
+  ]
+  stop_on_error = true
 
 [screen]
   clear_on_rebuild = false

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -1,8 +1,8 @@
 ---
 en:
+  forever: forever
   Heatmap: Heatmap
   "(Re)generate publicly shareable link": "(Re)generate publicly shareable link"
-  1 day: 1 day
   1 month: 1 month
   1 year: 1 year
   10 years: 10 years

--- a/views/helpers/statistics.go
+++ b/views/helpers/statistics.go
@@ -2,10 +2,10 @@ package helpers
 
 func StatisticSinceOptions() []string {
 	return []string{
-		"1 day",
 		"7 days",
 		"1 month", "3 months", "6 months",
 		"1 year", "2 years", "5 years", "10 years",
+		"forever",
 	}
 }
 


### PR DESCRIPTION
This commit improves the statistics query to handle the `since` parameter more gracefully.

The query only adds a date filter if the `since` parameter is not "forever". This change ensures that the statistics are calculated correctly for all time periods. Additionally, the translation for "forever" has been added to support this new functionality. Finally, the `since` options in the UI have been updated to allow selection of "forever".