### PR TITLE
fix(database): Handle zero duration in workout average speed calculation

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -544,7 +544,12 @@ func (w *Workout) setData(data *MapData) {
 }
 
 func (w *Workout) UpdateAverages() {
-	w.Data.AverageSpeed = w.Data.TotalDistance / w.Data.TotalDuration.Seconds()
+	if w.Data.TotalDuration == 0 {
+		w.Data.AverageSpeed = 0
+	} else {
+		w.Data.AverageSpeed = w.Data.TotalDistance / w.Data.TotalDuration.Seconds()
+	}
+
 	w.Data.AverageSpeedNoPause = w.Data.AverageSpeed
 }
 


### PR DESCRIPTION
The previous implementation of `UpdateAverages` could lead to a division by zero error if the workout's total duration was zero. This commit adds a check to handle this case, setting the average speed to 0 if the duration is 0, preventing the error and providing a more robust calculation. This ensures that the application remains stable even when processing workouts with zero duration.