### PR TITLE
fix(app): Fix redirect URLs after workout creation

### DIFF
--- a/pkg/app/workouts.go
+++ b/pkg/app/workouts.go
@@ -171,20 +171,20 @@ func (a *App) addWorkout(c echo.Context) error {
 	}
 
 	if err := c.Bind(&equipmentIDS); err != nil {
-		return a.redirectWithError(c, a.echo.Reverse("workout-edit", c.Param("id")), err)
+		return a.redirectWithError(c, a.echo.Reverse("workout-add"), err)
 	}
 
 	equipment, err := database.GetEquipmentByIDs(a.db, a.getCurrentUser(c).ID, equipmentIDS.EquipmentIDs)
 	if err != nil {
-		return a.redirectWithError(c, a.echo.Reverse("workout-edit", c.Param("id")), err)
+		return a.redirectWithError(c, a.echo.Reverse("workout-add"), err)
 	}
 
 	if err := workout.Save(a.db); err != nil {
-		return a.redirectWithError(c, a.echo.Reverse("workout-edit", c.Param("id")), err)
+		return a.redirectWithError(c, a.echo.Reverse("workout-add"), err)
 	}
 
 	if err := a.db.Model(&workout).Association("Equipment").Replace(equipment); err != nil {
-		return a.redirectWithError(c, a.echo.Reverse("workout-show", c.Param("id")), err)
+		return a.redirectWithError(c, a.echo.Reverse("workout-show", workout.ID), err)
 	}
 
 	a.addNotice(c, "The workout '%s' has been created.", workout.Name)

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -485,6 +485,13 @@ func (w *Workout) Save(db *gorm.DB) error {
 		w.UpdateAverages()
 	}
 
+	if w.ID == 0 {
+		if err := db.Save(w).Error; err != nil {
+			return err
+		}
+	}
+
+	w.Data.WorkoutID = w.ID
 	if err := w.Data.Save(db); err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous implementation used incorrect redirect URLs after creating or updating a workout. This commit updates the redirect URLs to correctly point to the "workout-add" route after creating a workout, and to the newly created workout's "workout-show" route after saving changes. This ensures users are redirected to the appropriate page after interacting with workouts. Additionally, it handles the case of saving a new workout without an ID, ensuring the `Workout.Data` is properly associated with the newly created workout.

Fixes #412