### PR TITLE
feat(api): Add endpoint to create manual workouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build-docker:
 swagger:
 	swag init \
 		--parseDependency \
-		--dir ./pkg/app/,./,./vendor/gorm.io/gorm/,./vendor/github.com/codingsince1985/geo-golang/ \
+		--dir ./pkg/app/,./pkg/database/,./vendor/gorm.io/gorm/,./vendor/github.com/codingsince1985/geo-golang/ \
 		--generalInfo api_handlers.go
 
 build-tw:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -59,7 +59,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Workout"
                                         }
                                     }
@@ -114,7 +114,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.WorkoutRecord"
                                         }
                                     }
@@ -174,7 +174,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Statistics"
                                         }
                                     }
@@ -228,7 +228,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Bucket"
                                         }
                                     }
@@ -274,7 +274,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.User"
                                         }
                                     }
@@ -320,11 +320,68 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/definitions/database.Workout"
                                             }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workouts/": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Create a new workout",
+                "parameters": [
+                    {
+                        "description": "Workout data",
+                        "name": "workout",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.ManualWorkout"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/app.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "#/definitions/app.ManualWorkout"
                                         }
                                     }
                                 }
@@ -383,7 +440,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/definitions/app.Event"
@@ -447,7 +504,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Workout"
                                         }
                                     }
@@ -514,7 +571,7 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.WorkoutBreakdown"
                                         }
                                     }
@@ -568,6 +625,47 @@ const docTemplate = `{
                 },
                 "url": {
                     "type": "string"
+                }
+            }
+        },
+        "app.ManualWorkout": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string"
+                },
+                "distance": {
+                    "type": "number"
+                },
+                "duration_hours": {
+                    "type": "integer"
+                },
+                "duration_minutes": {
+                    "type": "integer"
+                },
+                "duration_seconds": {
+                    "type": "integer"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "repetitions": {
+                    "type": "integer"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/database.WorkoutType"
+                },
+                "weight": {
+                    "type": "number"
                 }
             }
         },
@@ -1034,6 +1132,10 @@ const docTemplate = `{
                     "description": "The duration from the previous point",
                     "type": "integer"
                 },
+                "elevation": {
+                    "description": "The elevation of the point",
+                    "type": "number"
+                },
                 "extraMetrics": {
                     "description": "Extra metrics at this point",
                     "allOf": [
@@ -1249,10 +1351,6 @@ const docTemplate = `{
                 },
                 "lastID": {
                     "description": "The index of the first and last point of the route",
-                    "type": "integer"
-                },
-                "points": {
-                    "description": "The total number of points of the route segment for this workout",
                     "type": "integer"
                 },
                 "routeSegment": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -52,7 +52,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Workout"
                                         }
                                     }
@@ -107,7 +107,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.WorkoutRecord"
                                         }
                                     }
@@ -167,7 +167,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Statistics"
                                         }
                                     }
@@ -221,7 +221,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Bucket"
                                         }
                                     }
@@ -267,7 +267,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.User"
                                         }
                                     }
@@ -313,11 +313,68 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/definitions/database.Workout"
                                             }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/workouts/": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Create a new workout",
+                "parameters": [
+                    {
+                        "description": "Workout data",
+                        "name": "workout",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.ManualWorkout"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/app.APIResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "#/definitions/app.ManualWorkout"
                                         }
                                     }
                                 }
@@ -376,7 +433,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/definitions/app.Event"
@@ -440,7 +497,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.Workout"
                                         }
                                     }
@@ -507,7 +564,7 @@
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "result": {
+                                        "results": {
                                             "$ref": "#/definitions/database.WorkoutBreakdown"
                                         }
                                     }
@@ -561,6 +618,47 @@
                 },
                 "url": {
                     "type": "string"
+                }
+            }
+        },
+        "app.ManualWorkout": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string"
+                },
+                "distance": {
+                    "type": "number"
+                },
+                "duration_hours": {
+                    "type": "integer"
+                },
+                "duration_minutes": {
+                    "type": "integer"
+                },
+                "duration_seconds": {
+                    "type": "integer"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "repetitions": {
+                    "type": "integer"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/database.WorkoutType"
+                },
+                "weight": {
+                    "type": "number"
                 }
             }
         },
@@ -1027,6 +1125,10 @@
                     "description": "The duration from the previous point",
                     "type": "integer"
                 },
+                "elevation": {
+                    "description": "The elevation of the point",
+                    "type": "number"
+                },
                 "extraMetrics": {
                     "description": "Extra metrics at this point",
                     "allOf": [
@@ -1242,10 +1344,6 @@
                 },
                 "lastID": {
                     "description": "The index of the first and last point of the route",
-                    "type": "integer"
-                },
-                "points": {
-                    "description": "The total number of points of the route segment for this workout",
                     "type": "integer"
                 },
                 "routeSegment": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -17,6 +17,33 @@ definitions:
       url:
         type: string
     type: object
+  app.ManualWorkout:
+    properties:
+      date:
+        type: string
+      distance:
+        type: number
+      duration_hours:
+        type: integer
+      duration_minutes:
+        type: integer
+      duration_seconds:
+        type: integer
+      location:
+        type: string
+      name:
+        type: string
+      notes:
+        type: string
+      repetitions:
+        type: integer
+      timezone:
+        type: string
+      type:
+        $ref: '#/definitions/database.WorkoutType'
+      weight:
+        type: number
+    type: object
   database.BreakdownItem:
     properties:
       counter:
@@ -338,6 +365,9 @@ definitions:
       duration:
         description: The duration from the previous point
         type: integer
+      elevation:
+        description: The elevation of the point
+        type: number
       extraMetrics:
         allOf:
         - $ref: '#/definitions/database.ExtraMetrics'
@@ -485,9 +515,6 @@ definitions:
         type: integer
       lastID:
         description: The index of the first and last point of the route
-        type: integer
-      points:
-        description: The total number of points of the route segment for this workout
         type: integer
       routeSegment:
         $ref: '#/definitions/database.RouteSegment'
@@ -782,7 +809,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.Workout'
               type: object
         "400":
@@ -815,7 +842,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.WorkoutRecord'
               type: object
         "400":
@@ -851,7 +878,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.Statistics'
               type: object
         "400":
@@ -883,7 +910,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.Bucket'
               type: object
         "400":
@@ -910,7 +937,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.User'
               type: object
         "400":
@@ -937,7 +964,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   items:
                     $ref: '#/definitions/database.Workout'
                   type: array
@@ -955,6 +982,40 @@ paths:
           schema:
             $ref: '#/definitions/app.APIResponse'
       summary: List all workouts of the current user
+  /workouts/:
+    post:
+      parameters:
+      - description: Workout data
+        in: body
+        name: workout
+        required: true
+        schema:
+          $ref: '#/definitions/app.ManualWorkout'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/app.APIResponse'
+            - properties:
+                results:
+                  $ref: '#/definitions/app.ManualWorkout'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+      summary: Create a new workout
   /workouts/{id}:
     get:
       parameters:
@@ -976,7 +1037,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.Workout'
               type: object
         "400":
@@ -1017,7 +1078,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   $ref: '#/definitions/database.WorkoutBreakdown'
               type: object
         "400":
@@ -1053,7 +1114,7 @@ paths:
             allOf:
             - $ref: '#/definitions/app.APIResponse'
             - properties:
-                result:
+                results:
                   items:
                     $ref: '#/definitions/app.Event'
                   type: array

--- a/pkg/app/workouts.go
+++ b/pkg/app/workouts.go
@@ -33,18 +33,18 @@ func uploadedFile(file *multipart.FileHeader) ([]byte, error) {
 }
 
 type ManualWorkout struct {
-	Name            *string               `form:"name"`
-	Date            *string               `form:"date"`
-	Timezone        *string               `form:"timezone"`
-	Location        *string               `form:"location"`
-	DurationHours   *int                  `form:"duration_hours"`
-	DurationMinutes *int                  `form:"duration_minutes"`
-	DurationSeconds *int                  `form:"duration_seconds"`
-	Distance        *float64              `form:"distance"`
-	Repetitions     *int                  `form:"repetitions"`
-	Weight          *float64              `form:"weight"`
-	Notes           *string               `form:"notes"`
-	Type            *database.WorkoutType `form:"type"`
+	Name            *string               `form:"name" json:"name"`
+	Date            *string               `form:"date" json:"date"`
+	Timezone        *string               `form:"timezone" json:"timezone"`
+	Location        *string               `form:"location" json:"location"`
+	DurationHours   *int                  `form:"duration_hours" json:"duration_hours"`
+	DurationMinutes *int                  `form:"duration_minutes" json:"duration_minutes"`
+	DurationSeconds *int                  `form:"duration_seconds" json:"duration_seconds"`
+	Distance        *float64              `form:"distance" json:"distance"`
+	Repetitions     *int                  `form:"repetitions" json:"repetitions"`
+	Weight          *float64              `form:"weight" json:"weight"`
+	Notes           *string               `form:"notes" json:"notes"`
+	Type            *database.WorkoutType `form:"type" json:"type"`
 
 	units *database.UserPreferredUnits
 }
@@ -138,13 +138,15 @@ func (m *ManualWorkout) Update(w *database.Workout) {
 	setIfNotNil(&w.Data.TotalRepetitions, m.Repetitions)
 	setIfNotNil(&w.Data.TotalWeight, m.Weight)
 
-	a, err := geocoder.Find(*m.Location)
-	if err != nil {
-		w.Data.Address = nil
-		return
-	}
+	if w.Data.Address == nil && m.Location != nil {
+		a, err := geocoder.Find(*m.Location)
+		if err != nil {
+			w.Data.Address = nil
+			return
+		}
 
-	setIfNotNil(&w.Data.Address, &a)
+		w.Data.Address = a
+	}
 
 	w.Data.UpdateAddress()
 	w.Data.UpdateExtraMetrics()


### PR DESCRIPTION
Added an endpoint to create new workouts manually, using a POST request to `/workouts`. This allows users to add workouts without relying on automatic imports from external sources. The request body expects a JSON payload conforming to the `ManualWorkout` struct, providing fields such as date, time, location, distance, duration, and type of workout. The response returns a JSON object containing the newly created workout data. Error handling is included to manage invalid inputs and database errors. This significantly enhances the flexibility of the application by supporting manual data entry. The swagger documentation has also been updated to reflect this new endpoint. The `results` field in the API responses has been changed to plural.

Fixes #317