### PR TITLE
feat(cli): Add granular control over Fitbit data syncing

### DIFF
--- a/cmd/fitbit-sync/cli.go
+++ b/cmd/fitbit-sync/cli.go
@@ -13,7 +13,11 @@ import (
 
 type WorkoutConfig struct {
 	URL, APIKey string
-	persist     bool
+
+	syncWeight, syncHeight    bool
+	syncSteps, syncActivities bool
+
+	persist bool
 }
 
 func (c *WorkoutConfig) CopyFrom(o *WorkoutConfig) {

--- a/cmd/fitbit-sync/commands.go
+++ b/cmd/fitbit-sync/commands.go
@@ -121,6 +121,11 @@ func (fs *fitbitSync) syncCmd() *cobra.Command {
 	cmd.Flags().IntVarP(&days, "days", "d", 7, "Number of days to show")
 	cmd.Flags().StringVarP(&fs.WorkoutConfig.URL, "url", "u", "", "Workout Tracker root URL")
 	cmd.Flags().StringVarP(&fs.WorkoutConfig.APIKey, "key", "k", "", "Workout Tracker API key")
+	cmd.Flags().BoolVar(&fs.WorkoutConfig.syncWeight, "weight", true, "Sync weight from Fitbit")
+	cmd.Flags().BoolVar(&fs.WorkoutConfig.syncHeight, "height", true, "Sync height from Fitbit")
+	cmd.Flags().BoolVar(&fs.WorkoutConfig.syncSteps, "steps", true, "Sync steps from Fitbit")
+	cmd.Flags().BoolVar(&fs.WorkoutConfig.syncActivities, "activities", true, "Sync activities from Fitbit")
+
 	cmd.Flags().BoolVarP(&fs.WorkoutConfig.persist, "persist", "p", false, "Persist Workout Tracker configuration")
 
 	return cmd

--- a/cmd/fitbit-sync/sync.go
+++ b/cmd/fitbit-sync/sync.go
@@ -43,14 +43,16 @@ func (fs *fitbitSync) syncActivities(days int) {
 			continue
 		}
 
-		for _, a := range act.Activities {
-			if !a.HasStartTime {
-				continue
-			}
+		if fs.WorkoutConfig.syncActivities {
+			for _, a := range act.Activities {
+				if !a.HasStartTime {
+					continue
+				}
 
-			if err := fs.uploadActivity(a); err != nil {
-				log.Printf("could not sync activity TCX: %v", err)
-				continue
+				if err := fs.uploadActivity(a); err != nil {
+					log.Printf("could not sync activity TCX: %v", err)
+					continue
+				}
 			}
 		}
 
@@ -68,18 +70,25 @@ func (fs *fitbitSync) buildMeasurement(date string, final bool, units *fitbit.Un
 		Date: date,
 	}
 
-	if act.Summary != nil {
-		mw.Steps = float64(act.Summary.Steps)
+	if fs.WorkoutConfig.syncSteps {
+		if act.Summary != nil {
+			mw.Steps = float64(act.Summary.Steps)
+		}
 	}
 
 	if !final {
 		return mw
 	}
 
-	mw.Height = fs.profile.Height
-	mw.HeightUnit = units.Height
-	mw.Weight = fs.profile.Weight
-	mw.WeightUnit = units.Weight
+	if fs.WorkoutConfig.syncHeight {
+		mw.Height = fs.profile.Height
+		mw.HeightUnit = units.Height
+	}
+
+	if fs.WorkoutConfig.syncWeight {
+		mw.Weight = fs.profile.Weight
+		mw.WeightUnit = units.Weight
+	}
 
 	return mw
 }


### PR DESCRIPTION
This commit introduces more granular control over which Fitbit data is synced to the Workout Tracker. Previously, all available data (weight, height, steps, and activities) was synced by default. This update allows users to selectively enable or disable syncing for each data type using command-line flags.