### PR TITLE
Refactor(i18n): Rename Norwegian translation file

### DIFF
--- a/translations/nb_NO.yaml
+++ b/translations/nb_NO.yaml
@@ -1,3 +1,3 @@
 ---
-no:
+nb-NO:
   Welcome!: Velkomst!


### PR DESCRIPTION
Renamed the Norwegian translation file from `no.yaml` to `nb_NO.yaml` to better reflect the language code for Norwegian Bokmål. This improves clarity and consistency with other language files, ensuring that the correct language code is used for proper language detection and selection.