### PR TITLE
fix(i18n): Correct ellipsis in translations

### DIFF
--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -218,7 +218,7 @@ de:
   Update measurement: Messung aktualisieren
   The equipment '%s' has been deleted: Die Ausrüstung ‚%s‘ wurde gelöscht.
   The workout '%s' has been created: Das Training ‚%s‘ wurde erstellt.
-  The workout '%s' will be refreshed soon: Das Training ‚%s‘ wird bald aktualisiert...
+  The workout '%s' will be refreshed soon: Das Training ‚%s‘ wird bald aktualisiert…
   The route segment '%s' has been created - we search for matches in the background: Der
     Streckenabschnitt ‚%s‘ wurde erstellt - wir suchen im Hintergrund nach Übereinstimmungen.
   Height: Höhe

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -207,7 +207,7 @@ en:
   "The equipment '%s' has been deleted": The equipment '%s' has been deleted.
   "The equipment '%s' has been updated": The equipment '%s' has been updated.
   "You can find inspiration here:": "You can find inspiration here:"
-  "The workout '%s' will be refreshed soon": The workout '%s' will be refreshed soon...
+  "The workout '%s' will be refreshed soon": The workout '%s' will be refreshed soon…
   "The workout '%s' has been created": The workout '%s' has been created.
   "The route segment '%s' has been created - we search for matches in the background": "The route segment '%s' has been created - we search for matches in the background."
   "The route segment '%s' has been updated": "The route segment '%s' has been updated."

--- a/translations/fi.yaml
+++ b/translations/fi.yaml
@@ -195,7 +195,7 @@ fi:
   Resources: Resurssit
   'You can find inspiration here:': 'Täältä löydät inspiraatiota:'
   The workout '%s' has been refreshed: Harjoitus '%s' on virkistetty.
-  The workout '%s' will be refreshed soon: Harjoitus '%s' virkistetään pian...
+  The workout '%s' will be refreshed soon: Harjoitus '%s' virkistetään pian…
   alerts:
     workouts_added:
       one: 'Kohdattiin %{count} ongelmaa harjoitusten lisäämisessä: %{list}'

--- a/translations/nl.yaml
+++ b/translations/nl.yaml
@@ -215,7 +215,7 @@ nl:
   forever: voor altijd
   The equipment '%s' has been deleted: Het materiaal '%s' werd verwijderd.
   The equipment '%s' has been updated: Het materiaal '%s' werd aangepast.
-  The workout '%s' will be refreshed soon: De workout '%s' wordt binnenkort ververst...
+  The workout '%s' will be refreshed soon: De workout '%s' wordt binnenkort ververst…
   The workout '%s' has been created: De workout '%s' werd gemaakt.
   The route segment '%s' has been created - we search for matches in the background: Het
     route segment '%s' werd aangemaakt - we zoeken op de achtergrond naar matches.

--- a/translations/zh_Hans.yaml
+++ b/translations/zh_Hans.yaml
@@ -207,7 +207,7 @@ zh-Hans:
   The equipment '%s' has been deleted: 设备 '%s' 已删除。
   The equipment '%s' has been updated: 设备 '%s' 已更新。
   'You can find inspiration here:': 您可以在此找到灵感：
-  The workout '%s' will be refreshed soon: 锻炼 '%s' 将很快刷新...
+  The workout '%s' will be refreshed soon: 锻炼 '%s' 将很快刷新…
   The workout '%s' has been created: 锻炼 '%s' 已创建。
   The route segment '%s' has been created - we search for matches in the background: 路线片段
     '%s' 已创建 - 我们在后台搜索匹配项。


### PR DESCRIPTION
The ellipsis was rendered incorrectly as "...". This commit replaces the three dots with the ellipsis character "…" to ensure proper rendering across different platforms and character encodings. This affects the translations for German, English, Finnish, Dutch, and Simplified Chinese.