### PR TITLE
fix(fit): skip invalid coordinates

### DIFF
--- a/pkg/converters/fit.go
+++ b/pkg/converters/fit.go
@@ -47,6 +47,10 @@ func ParseFit(content []byte) (*gpx.GPX, error) {
 			},
 		}
 
+		if math.IsNaN(p.Latitude) || math.IsNaN(p.Longitude) {
+			continue
+		}
+
 		if a := r.EnhancedAltitudeScaled(); !math.IsNaN(a) {
 			p.Elevation = *gpx.NewNullableFloat64(a)
 		}


### PR DESCRIPTION
This commit fixes an issue where invalid coordinates (NaN) in FIT files would cause parsing issues.

The code now skips records with NaN latitude or longitude values, preventing the creation of invalid GPX points. This ensures that the converter can process FIT files with potentially corrupted location data.