### PR TITLE
fix(db): use bytes type for content fields

### DIFF
--- a/pkg/database/route_segments.go
+++ b/pkg/database/route_segments.go
@@ -45,7 +45,7 @@ type RouteSegment struct {
 
 	Points []MapPoint `gorm:"serializer:json"` // The GPS points of the workout
 
-	Content             []byte               `gorm:"type:text"`            // The file content
+	Content             []byte               `gorm:"type:bytes"`           // The file content
 	Checksum            []byte               `gorm:"not null;uniqueIndex"` // The checksum of the content
 	RouteSegmentMatches []*RouteSegmentMatch // The matches of the route segment
 	Center              MapCenter            `gorm:"serializer:json"` // The center of the workout (in coordinates)

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -47,7 +47,7 @@ type Workout struct {
 type GPXData struct {
 	Model
 	Filename  string // The filename of the file
-	Content   []byte `gorm:"type:text"`            // The file content
+	Content   []byte `gorm:"type:bytes"`           // The file content
 	Checksum  []byte `gorm:"not null;uniqueIndex"` // The checksum of the content
 	WorkoutID uint64 `gorm:"not null;uniqueIndex"` // The ID of the workout
 }


### PR DESCRIPTION
The `Content` fields in `RouteSegment` and `GPXData` schemas were defined with `gorm:"type:text"`. This change updates the type to `gorm:"type:bytes"` which is more appropriate for storing binary data like file content. This fixes issues related to character encoding and ensures data integrity when storing and retrieving file content from the database.

Specifically, this fixes storing fit files in a PostgreSQL database.