### PR TITLE
fix(statistics): translate statistics page

### DIFF
--- a/pkg/app/handlers.go
+++ b/pkg/app/handlers.go
@@ -36,8 +36,8 @@ func (a *App) statisticsHandler(c echo.Context) error {
 		Since string `query:"since"`
 		Per   string `query:"per"`
 	}{
-		Since: "misc.years_1",
-		Per:   "misc.month",
+		Since: "1 year",
+		Per:   "month",
 	}
 
 	if err := c.Bind(&statisticsParams); err != nil {

--- a/views/helpers/helpers.go
+++ b/views/helpers/helpers.go
@@ -39,6 +39,16 @@ type TranslatedKey struct {
 	Translation string
 }
 
+func FindTranslationForKey(tks []TranslatedKey, key string) string {
+	for _, tk := range tks {
+		if tk.Key == key {
+			return tk.Translation
+		}
+	}
+
+	return ""
+}
+
 func OrderDirOptions() []TranslatedKey {
 	return []TranslatedKey{
 		{"asc", "translation.ascending"},

--- a/views/user/statistics.templ
+++ b/views/user/statistics.templ
@@ -11,7 +11,7 @@ templ Statistics(u *database.User, since, per string) {
 	@partials.Page(partials.NewPageOptions().WithCharts()) {
 		<h2>
 			@helpers.IconFor("statistics")
-			{ i18n.T(ctx, "translation.Your_progress_per_s_for_the_past_s", i18n.T(ctx, per), i18n.T(ctx, since)) }
+			{ i18n.T(ctx, "translation.Your_progress_per_s_for_the_past_s", i18n.T(ctx, helpers.FindTranslationForKey(helpers.StatisticPerOptions(), per)), i18n.T(ctx, helpers.FindTranslationForKey(helpers.StatisticSinceOptions(), since))) }
 		</h2>
 		<div class="content">
 			<form class="inner-form">

--- a/views/user/statistics_templ.go
+++ b/views/user/statistics_templ.go
@@ -57,9 +57,9 @@ func Statistics(u *database.User, since, per string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "translation.Your_progress_per_s_for_the_past_s", i18n.T(ctx, per), i18n.T(ctx, since)))
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "translation.Your_progress_per_s_for_the_past_s", i18n.T(ctx, helpers.FindTranslationForKey(helpers.StatisticPerOptions(), per)), i18n.T(ctx, helpers.FindTranslationForKey(helpers.StatisticSinceOptions(), since))))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/user/statistics.templ`, Line: 14, Col: 104}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/user/statistics.templ`, Line: 14, Col: 230}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
This commit fixes the statistics page by using the correct keys for translations.

Fixes #516