### PR TITLE
fix(measurement): ensure correct measurement timezone handling

### DIFF
--- a/pkg/database/measurement.go
+++ b/pkg/database/measurement.go
@@ -19,7 +19,7 @@ type Measurement struct {
 func (u *User) NewMeasurement(d time.Time) *Measurement {
 	return &Measurement{
 		UserID: u.ID,
-		Date:   datatypes.Date(d.UTC()),
+		Date:   datatypes.Date(d),
 	}
 }
 

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -327,7 +327,7 @@ func (u *User) GetLatestMeasurements(c int) ([]*Measurement, error) {
 func (u *User) GetCurrentMeasurement() (*Measurement, error) {
 	var m *Measurement
 
-	d := time.Now().UTC()
+	d := time.Now().In(u.Timezone())
 
 	if err := u.db.Where(&Measurement{UserID: u.ID}).Where("date = ?", datatypes.Date(d)).First(&m).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
This commit fixes an issue where measurements were not being saved with the
correct timezone. The `NewMeasurement` function now creates measurements using
the user's timezone. Also, the `GetCurrentMeasurement` function now retrieves
measurements using the user's timezone. This ensures that measurements are
always saved and retrieved with the correct date.

Fixes #521
