### PR TITLE
feat(workouts): Add Open GPX Tracker for iOS to trusted altitude sources

### DIFF
--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -23,7 +23,7 @@ const UnknownLocation = "(unknown location)"
 
 var correctAltitudeCreators = []string{
 	"garmin", "Garmin", "Garmin Connect",
-	"Apple Watch",
+	"Apple Watch", "Open GPX Tracker for iOS",
 	"StravaGPX iPhone", "StravaGPX",
 	"Workout Tracker",
 }


### PR DESCRIPTION
Include "Open GPX Tracker for iOS" in the list of workout creators whose provided altitude data is considered reliable.

This ensures that altitude information from workouts created by this specific app is used directly, assuming its data is accurate, rather than calculating the height of the EGM96 geoid.

Fixes #531