### PR TITLE
fix(database): Prevent pre-migration error on missing columns

### DIFF
--- a/pkg/database/gorm.go
+++ b/pkg/database/gorm.go
@@ -85,6 +85,10 @@ func preMigrationActions(db *gorm.DB) error {
 	}
 
 	for _, k := range []string{"average_speed", "average_speed_no_pause"} {
+		if !db.Migrator().HasColumn(&MapData{}, k) {
+			continue
+		}
+
 		q := db.
 			Model(&MapData{}).Where(k+" in ?", []float64{math.Inf(1), math.Inf(-1), math.NaN()}).
 			Update(k, 0)


### PR DESCRIPTION
Add a check for column existence before attempting to update `average_speed` and `average_speed_no_pause`.

This prevents errors during database setup or migration on tables where these specific columns might not yet or no longer exist, improving the robustness of the pre-migration steps.

Fixes #542