### PR TITLE
refactor(handlers): Extract calendar API handler

### DIFF
--- a/pkg/app/api_calendar_handlers.go
+++ b/pkg/app/api_calendar_handlers.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/a-h/templ"
+	"github.com/jovandeginste/workout-tracker/v2/views/workouts"
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+type Event struct {
+	Title string    `json:"title"`
+	Start time.Time `json:"start"`
+	URL   string    `json:"url"`
+}
+
+type calendarQueryParams struct {
+	Start *string `query:"start"`
+	End   *string `query:"end"`
+}
+
+func (cqp calendarQueryParams) SetStart(db *gorm.DB) *gorm.DB {
+	if cqp.Start == nil {
+		return db
+	}
+
+	start, err := time.Parse(calTS, *cqp.Start)
+	if err != nil {
+		return db
+	}
+
+	return db.Where("workouts.date >= ?", start)
+}
+
+func (cqp calendarQueryParams) SetEnd(db *gorm.DB) *gorm.DB {
+	if cqp.End == nil {
+		return db
+	}
+
+	end, err := time.Parse(calTS, *cqp.End)
+	if err != nil {
+		return db
+	}
+
+	return db.Where("workouts.date <= ?", end)
+}
+
+// apiCalendar returns the calendar events of all workouts of the current user
+// @Summary      List the calendar events of all workouts of the current user
+// @Param        start query    string false "Start date of the calendar view"
+// @Param        end query    string false "End date of the calendar view"
+// @Produce      json
+// @Success      200  {object}  APIResponse{results=[]Event}
+// @Failure      400  {object}  APIResponse
+// @Failure      404  {object}  APIResponse
+// @Failure      500  {object}  APIResponse
+// @Router       /workouts/coordinates [get]
+func (a *App) apiCalendar(c echo.Context) error {
+	resp := APIResponse{}
+	events := []Event{}
+	queryParams := calendarQueryParams{}
+
+	if err := c.Bind(&queryParams); err != nil {
+		return a.renderAPIError(c, resp, err)
+	}
+
+	u := a.getCurrentUser(c)
+	db := a.db.Preload("Data").Preload("Data.Details")
+
+	db = queryParams.SetStart(db)
+	db = queryParams.SetEnd(db)
+
+	wos, err := u.GetWorkouts(db)
+	if err != nil {
+		return a.renderAPIError(c, resp, err)
+	}
+
+	for _, w := range wos {
+		buf := templ.GetBuffer()
+		defer templ.ReleaseBuffer(buf)
+
+		t := workouts.EventTitle(w, u.PreferredUnits())
+		if err := t.Render(c.Request().Context(), buf); err != nil {
+			return a.renderAPIError(c, resp, err)
+		}
+
+		d := buf.String()
+		// Remove all newlines and surrounding whitespace
+		d = htmlConcatenizer.ReplaceAllString(d, "")
+
+		events = append(events, Event{
+			Title: d,
+			Start: w.Date,
+			URL:   a.echo.Reverse("workout-show", w.ID),
+		})
+	}
+
+	resp.Results = events
+
+	return c.JSON(http.StatusOK, resp)
+}


### PR DESCRIPTION
Move the `apiCalendar` handler and its associated types to a new `api_calendar_handlers.go` file. This refactoring improves the separation of concerns by dedicating a file to calendar-related API logic, reducing the size and complexity of `api_handlers.go`, and making the codebase easier to navigate and maintain.

Introduce `calendarQueryParams` to encapsulate the logic for handling `start` and `end` query parameters. This change centralizes date parsing and database filtering for calendar queries, making the handler cleaner and more robust by explicitly handling potential parsing errors for date parameters.

Define `calTS` (calendar timestamp) constant for the expected date format. This constant makes the date format explicit and ensures consistency across date parsing operations related to the calendar, improving readability and maintainability.

Fixes #577