### PR TITLE
feat(statistics): Distinguish aggregation bucket from representative day

### DIFF
--- a/pkg/database/user_statistics.go
+++ b/pkg/database/user_statistics.go
@@ -23,6 +23,7 @@ type (
 	// Bucket is the consolidation of workout information for a given time bucket
 	Bucket struct {
 		Bucket              string        `json:"bucket,omitempty"`              // The name of the bucket
+		RawBucket           string        `json:"raw_bucket,omitempty"`          // One day in the bucket (for statistic rendering)
 		WorkoutType         WorkoutType   `json:"workoutType"`                   // The type of the workout
 		Workouts            int           `json:"workouts"`                      // The number of workouts in the bucket
 		Distance            float64       `json:"distance,omitempty"`            // The total distance in the bucket


### PR DESCRIPTION
Introduce `RawBucket` field in the `Bucket` struct to clearly separate the aggregation period from a representative day within that period. This field now stores the actual bucket string used for grouping (e.g., '2023-W40', '2023-10').

Rename the SQL alias for the primary bucket column from `bucket` to `raw_bucket` in `GetBucketFormatExpression`. This aligns the database query output with the new `RawBucket` struct field.

Add `GetDayBucketFormatExpression` to select a `YYYY-MM-DD` formatted date as `bucket`. This ensures the `Bucket` field in the struct consistently holds a specific date, which is crucial for frontend rendering, allowing charts to plot data points with precise date values even when aggregated by week or month.

Update the `GROUP BY` clause to use the `raw_bucket` alias, maintaining correct data aggregation based on the defined period.

Fixes #574