### PR TITLE
fix(ui): restore the recent activities section

### DIFF
--- a/views/user/show.templ
+++ b/views/user/show.templ
@@ -50,6 +50,7 @@ templ Show(user *database.User, users []*database.User, wos []*database.Workout,
 					}
 				</div>
 			</div>
+		}
 			<div class="inner-form recent-activity">
 				<h3>
 					@helpers.IconFor("workout")
@@ -61,6 +62,5 @@ templ Show(user *database.User, users []*database.User, wos []*database.Workout,
 					}
 				</div>
 			</div>
-		}
 	}
 }


### PR DESCRIPTION
In #572, I didn't see that the "recent activities" section was under the `if len(users) > 0 {` block.

I think we have to display the recent activities, even if we have a single user on the instance. 