### PR TITLE
feat(config): Add web root configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Other environment variables, with their default values:
 
 ```bash
 WT_BIND="[::]:8080"
+WT_WEB_ROOT="/my-workout-tracker"
 WT_LOGGING="true"
 WT_DEBUG="false"
 WT_DATABASE_DRIVER="sqlite"
@@ -459,5 +460,5 @@ application is tested with GPX files from these sources:
 - add support for other types of import files (eg. Garmin fit files)
   - importing fit files works, kinda: there seems to be an issue with the
     elevation
-  - see https://github.com/tormoder/fit/issues/87
-  - https://www.fitfileviewer.com/ gives the same elevation issue
+  - see <https://github.com/tormoder/fit/issues/87>
+  - <https://www.fitfileviewer.com/> gives the same elevation issue

--- a/workout-tracker.example.yaml
+++ b/workout-tracker.example.yaml
@@ -4,3 +4,6 @@ jwt_encryption_key: some_long_random_string
 debug: false
 # Which host and port to bind on
 bind: "[::]:80"
+
+# The root path of the web application
+web_root: /my-workout-tracker


### PR DESCRIPTION
Add `WT_WEB_ROOT` environment variable and `web_root` YAML configuration example
to allow specifying the base path for the web application.

Update URL formatting in README.md to use the `<URL>` syntax. This ensures
consistent rendering and linking of URLs across different Markdown renderers.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
