### PR TITLE
feat(metrics) use enhanced speed readings from gpx files

### DIFF
--- a/pkg/converters/fit.go
+++ b/pkg/converters/fit.go
@@ -55,27 +55,28 @@ func ParseFit(content []byte) (*gpx.GPX, error) {
 			p.Elevation = *gpx.NewNullableFloat64(r.EnhancedAltitudeScaled())
 		}
 
-		if r.EnhancedSpeed != math.MaxUint32 {
-			p.Extensions.Nodes = append(p.Extensions.Nodes, gpx.ExtensionNode{
-				XMLName: xml.Name{Local: "enhanced-speed"}, Data: cast.ToString(r.EnhancedSpeedScaled()),
-			})
+		gpxExtensionData := map[string]string{}
+		if r.Cadence != math.MaxUint8 {
+			gpxExtensionData["cadence"] = cast.ToString(r.Cadence)
 		}
 
 		if r.HeartRate != math.MaxUint8 {
-			p.Extensions.Nodes = append(p.Extensions.Nodes, gpx.ExtensionNode{
-				XMLName: xml.Name{Local: "heart-rate"}, Data: cast.ToString(r.HeartRate),
-			})
+			gpxExtensionData["heart-rate"] = cast.ToString(r.HeartRate)
 		}
 
-		if r.Cadence != math.MaxUint8 {
-			p.Extensions.Nodes = append(p.Extensions.Nodes, gpx.ExtensionNode{
-				XMLName: xml.Name{Local: "cadence"}, Data: cast.ToString(r.Cadence),
-			})
+		if r.EnhancedSpeed != math.MaxUint32 {
+			gpxExtensionData["speed"] = cast.ToString(r.EnhancedSpeedScaled())
+		} else if r.Speed != math.MaxUint16 {
+			gpxExtensionData["speed"] = cast.ToString(r.SpeedScaled())
 		}
 
 		if r.Temperature != math.MaxInt8 {
+			gpxExtensionData["temperature"] = cast.ToString(r.Temperature)
+		}
+
+		for key, value := range gpxExtensionData {
 			p.Extensions.Nodes = append(p.Extensions.Nodes, gpx.ExtensionNode{
-				XMLName: xml.Name{Local: "temperature"}, Data: cast.ToString(r.Temperature),
+				XMLName: xml.Name{Local: key}, Data: value,
 			})
 		}
 

--- a/pkg/database/extra_metrics.go
+++ b/pkg/database/extra_metrics.go
@@ -47,10 +47,12 @@ func standardExtensionName(name string) string {
 		return "horizontal-accuracy"
 	case "vAcc": // vertical accuracy estimate [mm]
 		return "vertical-accuracy"
-	case "ns3:hr", "hr":
+	case "ns3:hr", "hr", "heartrate":
 		return "heart-rate"
 	case "ns3:cad", "cad":
 		return "cadence"
+	case "atemp", "temp":
+		return "temperature"
 	default:
 		return name
 	}

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -742,16 +742,12 @@ func (w *Workout) HasElevation() bool {
 	return w.HasExtraMetric("elevation")
 }
 
-func (w *Workout) HasSpeed() bool {
+func (w *Workout) HasEnhancedSpeed() bool {
 	return w.HasExtraMetric("speed")
 }
 
 func (w *Workout) HasTemperature() bool {
 	return w.HasExtraMetric("temperature")
-}
-
-func (w *Workout) HasEnhancedSpeed() bool {
-	return w.HasExtraMetric("enhanced-speed")
 }
 
 func (w *Workout) HasCadence() bool {

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -12,7 +12,6 @@ import (
 	"github.com/labstack/gommon/log"
 	"github.com/paulmach/orb"
 	"github.com/ringsaturn/tzf"
-	"github.com/spf13/cast"
 	"github.com/tkrajina/gpxgo/gpx"
 	"github.com/westphae/geomag/pkg/egm96"
 	"gorm.io/gorm"
@@ -340,8 +339,10 @@ func maxSpeedForSegment(segment gpx.GPXTrackSegment) float64 {
 	ms := segment.MovingData().MaxSpeed
 
 	for _, p := range segment.Points {
-		if n, ok := p.Extensions.GetNode("", "enhanced-speed"); ok {
-			if newMS, err := cast.ToFloat64E(n.Data); err == nil && newMS > ms {
+		extraMetrics := ExtraMetrics{}
+		extraMetrics.ParseGPXExtensions(p.Extensions)
+		if newMS, ok := extraMetrics["speed"]; ok {
+			if newMS > ms {
 				ms = newMS
 			}
 		}

--- a/views/workouts/details.templ
+++ b/views/workouts/details.templ
@@ -426,7 +426,7 @@ templ FullWorkoutDetails(w *database.Workout) {
 						}
 						if w.HasEnhancedSpeed() {
 							<div title={ i18n.T(ctx, "translation.enhanced_speed") }>
-								@helpers.IconFor("max-speed")
+								@helpers.IconFor("speed")
 							</div>
 						}
 						if w.HasTemperature() {
@@ -437,11 +437,6 @@ templ FullWorkoutDetails(w *database.Workout) {
 						if w.HasHeading() {
 							<div title={ i18n.T(ctx, "translation.Heading") }>
 								@helpers.IconFor("heading")
-							</div>
-						}
-						if w.HasSpeed() {
-							<div title={ i18n.T(ctx, "translation.Speed") }>
-								@helpers.IconFor("speed")
 							</div>
 						}
 						if w.HasAccuracy() {

--- a/views/workouts/details_templ.go
+++ b/views/workouts/details_templ.go
@@ -1872,7 +1872,7 @@ func FullWorkoutDetails(w *database.Workout) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = helpers.IconFor("max-speed").Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = helpers.IconFor("speed").Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1935,15 +1935,15 @@ func FullWorkoutDetails(w *database.Workout) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			if w.HasSpeed() {
+			if w.HasAccuracy() {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "<div title=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var103 string
-				templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "translation.Speed"))
+				templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "translation.Accuracy"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/workouts/details.templ`, Line: 443, Col: 52}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/workouts/details.templ`, Line: 443, Col: 55}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 				if templ_7745c5c3_Err != nil {
@@ -1953,7 +1953,7 @@ func FullWorkoutDetails(w *database.Workout) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = helpers.IconFor("speed").Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = helpers.IconFor("accuracy").Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1962,39 +1962,12 @@ func FullWorkoutDetails(w *database.Workout) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			if w.HasAccuracy() {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "<div title=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var104 string
-				templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(i18n.T(ctx, "translation.Accuracy"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/workouts/details.templ`, Line: 448, Col: 55}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = helpers.IconFor("accuracy").Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "</tbody></table>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "</tbody></table>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Speed from speed sensors seems to be commly saved to the `speed` field in gpx files. I already added this in #576 because I was planning to fix the same problem with speed readings. 

So here I am doing some changes for your fix to also work with gpx files and remove my now unnecessarily added metric icon. 