### PR TITLE
Feat: Import workout type from GPX name field.

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -346,7 +346,7 @@ func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string,
 		}
 
 		if workoutType == WorkoutTypeAutoDetect {
-			workoutType = autoDetectWorkoutType(data, g.GPX)
+			workoutType = autoDetectWorkoutType(data, g.GPX, g.Data.Name)
 		}
 
 		w := &Workout{
@@ -418,7 +418,7 @@ func workoutTypeFromData(gpxType string) (WorkoutType, bool) {
 	}
 }
 
-func autoDetectWorkoutType(data *MapData, gpxContent *gpx.GPX) WorkoutType {
+func autoDetectWorkoutType(data *MapData, gpxContent *gpx.GPX, dataName string) WorkoutType {
 	if gpxContent == nil {
 		if workoutType, ok := workoutTypeFromData(data.Type); ok {
 			return workoutType
@@ -433,6 +433,16 @@ func autoDetectWorkoutType(data *MapData, gpxContent *gpx.GPX) WorkoutType {
 
 		if workoutType, ok := workoutTypeFromData(firstTrack.Type); ok {
 			return workoutType
+		}
+	}
+
+	// If the GPX file mentions a workout type in the name (Runkeeper), use it
+	if len(dataName) > 0 {
+		nameField := strings.Fields(dataName)
+		if len(nameField) > 0 {
+			if workoutType, ok := workoutTypeFromData(nameField[0]); ok {
+				return workoutType
+			}
 		}
 	}
 


### PR DESCRIPTION
Runkeeper exports specify the workout activity type (e.g., “running”, “skating”) only in the GPX \<name\> field. This change ensures the correct activity type is set when importing from Runkeeper.

Examples of Runkeeper export:
```
<?xml version="1.0" encoding="UTF-8"?>
<gpx
  version="1.1"
  creator="Runkeeper - http://www.runkeeper.com"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns="http://www.topografix.com/GPX/1/1"
  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
  xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
<trk>
  <name><![CDATA[Skating 7/9/21 8:00 pm]]></name>
  <time>2021-07-09T18:00:47Z</time>
<trkseg>
[..]
```

```
<?xml version="1.0" encoding="UTF-8"?>
<gpx
  version="1.1"
  creator="Runkeeper - http://www.runkeeper.com"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns="http://www.topografix.com/GPX/1/1"
  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
  xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
<trk>
  <name><![CDATA[Running 8/1/19 7:22 pm]]></name>
  <time>2019-08-01T17:22:36Z</time>
<trkseg>
[..]
```