### PR TITLE
feat(stats): Allow users to customize displayed total statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,36 @@
 ## What's Changed
 
-- build(swagger): Automate committing generated documentation
-- chore(templates): Generate templates with new version of templ
-- feat(web): Add configurable web root
+- feat(stats): Allow users to customize displayed total statistics
+- Translations update from Hosted Weblate, by @jovandeginste, in
+  [#604](https://github.com/jovandeginste/workout-tracker/pull/604)
+  - Translated using Weblate (Russian), by @yurtpage
+- feat(metrics): Add enhanced speed and temperature to workouts, by
+  @jovandeginste, in
+  [#603](https://github.com/jovandeginste/workout-tracker/pull/603)
+- refactor(conversions): Replace strconv with spf13/cast, by @jovandeginste, in
+  [#602](https://github.com/jovandeginste/workout-tracker/pull/602)
+  - refactor(conversions): Replace strconv with spf13/cast or fmt, by
+    @jovandeginste
+- feat(config): Add web root configuration examples, by @jovandeginste, in
+  [#601](https://github.com/jovandeginste/workout-tracker/pull/601)
+- feat(calendar): Implement timezone support for calendar view, by
+  @jovandeginste, in
+  [#600](https://github.com/jovandeginste/workout-tracker/pull/600)
+- Fix zero division errors for workouts with total duration of 0, by
+  @jovandeginste, in
+  [#596](https://github.com/jovandeginste/workout-tracker/pull/596)
+  - Fix zero division errors for workouts with total duration of 0, by
+    @bastianjoel
+- feat(web): Add configurable web root, by @jovandeginste, in
+  [#599](https://github.com/jovandeginste/workout-tracker/pull/599)
+  - build(swagger): Automate committing generated documentation, by
+    @jovandeginste
+  - chore(templates): Generate templates with new version of templ, by
+    @jovandeginste
+  - feat(web): Add configurable web root, by @jovandeginste
+- chore(deps): bump golang from 1.24.4-alpine to 1.24.5-alpine, by
+  @jovandeginste, in
+  [#589](https://github.com/jovandeginste/workout-tracker/pull/589)
 - chore(deps): bump the all group with 9 updates, by @jovandeginste, in
   [#598](https://github.com/jovandeginste/workout-tracker/pull/598)
 - Fix `AverageSpeedNoPause` not updated correctly, by @jovandeginste, in

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1814,6 +1814,7 @@ const docTemplate = `{
         "database.WorkoutType": {
             "type": "string",
             "enum": [
+                "unknown",
                 "auto",
                 "running",
                 "cycling",
@@ -1831,6 +1832,7 @@ const docTemplate = `{
                 "other"
             ],
             "x-enum-varnames": [
+                "WorkoutTypeUnknown",
                 "WorkoutTypeAutoDetect",
                 "WorkoutTypeRunning",
                 "WorkoutTypeCycling",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1807,6 +1807,7 @@
         "database.WorkoutType": {
             "type": "string",
             "enum": [
+                "unknown",
                 "auto",
                 "running",
                 "cycling",
@@ -1824,6 +1825,7 @@
                 "other"
             ],
             "x-enum-varnames": [
+                "WorkoutTypeUnknown",
                 "WorkoutTypeAutoDetect",
                 "WorkoutTypeRunning",
                 "WorkoutTypeCycling",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -752,6 +752,7 @@ definitions:
     type: object
   database.WorkoutType:
     enum:
+    - unknown
     - auto
     - running
     - cycling
@@ -769,6 +770,7 @@ definitions:
     - other
     type: string
     x-enum-varnames:
+    - WorkoutTypeUnknown
     - WorkoutTypeAutoDetect
     - WorkoutTypeRunning
     - WorkoutTypeCycling

--- a/pkg/database/workout_type.go
+++ b/pkg/database/workout_type.go
@@ -10,6 +10,7 @@ type (
 )
 
 const (
+	WorkoutTypeUnknown       WorkoutType = "unknown"
 	WorkoutTypeAutoDetect    WorkoutType = "auto"
 	WorkoutTypeRunning       WorkoutType = "running"
 	WorkoutTypeCycling       WorkoutType = "cycling"
@@ -136,6 +137,10 @@ func (wt WorkoutType) StringT() string {
 }
 
 func (wt WorkoutType) String() string {
+	if wt == "" {
+		return string(WorkoutTypeUnknown)
+	}
+
 	return string(wt)
 }
 

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -38,6 +38,8 @@ en:
     remove_the_beginning_or_the_ending_of_a_workout: remove the beginning or the ending
       of a workout
   sports:
+    auto: auto-detect
+    unknown: unknown
     cycling: cycling
     e-cycling: e-cycling
     golfing: golfing

--- a/views/user/stats.templ
+++ b/views/user/stats.templ
@@ -15,7 +15,7 @@ templ StatsRecordsTotal(user *database.User) {
 	} else {
 		{{ preferredUnits := helpers.CurrentUser(ctx).PreferredUnits() }}
 		<div class="md:flex md:flex-wrap">
-			@StatisticTile(totals.WorkoutType.String(), i18n.T(ctx, totals.WorkoutType.StringT()), helpers.A2S(totals.Workouts), "")
+			@StatisticTile(user.Profile.TotalsShow.String(), i18n.T(ctx, user.Profile.TotalsShow.StringT()), helpers.A2S(totals.Workouts), "")
 			@StatisticTile("distance", i18n.T(ctx, "translation.distance"), helpers.HumanDistance(ctx, totals.Distance), preferredUnits.Distance())
 			@StatisticTile("up", i18n.T(ctx, "translation.up"), helpers.HumanElevation(ctx, totals.Up), preferredUnits.Elevation())
 			@StatisticTile("duration", i18n.T(ctx, "translation.duration"), helpers.HumanDuration(totals.Duration), "")

--- a/views/user/stats_templ.go
+++ b/views/user/stats_templ.go
@@ -62,7 +62,7 @@ func StatsRecordsTotal(user *database.User) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = StatisticTile(totals.WorkoutType.String(), i18n.T(ctx, totals.WorkoutType.StringT()), helpers.A2S(totals.Workouts), "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = StatisticTile(user.Profile.TotalsShow.String(), i18n.T(ctx, user.Profile.TotalsShow.StringT()), helpers.A2S(totals.Workouts), "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Handle empty workout types by returning "none" for their string representation.
This provides a clear identifier for an unselected workout type, which is then
used in UI elements.

Add 'none' and 'auto-detect' translations for sports.

Display the first statistic tile based on the user's `Profile.TotalsShow`
preference instead of the query results. This should be the same as the results
from the query, except when the query returns no results (in which case, the
value from the profile makes more sense!)

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
