### PR TITLE
feat: user can control some options in heatmap

### DIFF
--- a/frontend/src/views/user/heatmap.js
+++ b/frontend/src/views/user/heatmap.js
@@ -75,10 +75,18 @@ class WtHeatmap extends HTMLElement {
       const radius = L.DomUtil.get("radius").value;
       const blur = L.DomUtil.get("blur").value;
       const showMarkers = L.DomUtil.get("showMarkers").checked;
-      heatLayer = L.heatLayer(heatMapData, {
+      const onlyTrace = L.DomUtil.get("onlyTrace").checked;
+      var config = {
         radius: Number(radius),
         blur: Number(blur),
-      });
+      };
+      if (onlyTrace) {
+        config.radius = 1;
+        config.blur = 1;
+        config.minOpacity = 1;
+        config.gradient = { 0: "blue" };
+      }
+      heatLayer = L.heatLayer(heatMapData, config);
       heatLayer.addTo(map);
       if (showMarkers) {
         markers.addTo(map);
@@ -95,9 +103,10 @@ class WtHeatmap extends HTMLElement {
 
         container.style.backgroundColor = "white";
         container.innerHTML = `
-        <div class="flex items-center"><label for="radius" class="w-12">Radius </label><input class="p-0" type="range" id="radius" value="10" min="5" max="30"/></div>
-        <div class="flex items-center"><label for="blur" class="w-12">Blur </label><input class="p-0" type="range" id="blur" value="15" min="5" max="30"/></div>
+        <div class="flex items-center"><label for="radius" class="w-12">Radius</label><input class="p-0" type="range" id="radius" value="10" min="1" max="30"/></div>
+        <div class="flex items-center"><label for="blur" class="w-12">Blur</label><input class="p-0" type="range" id="blur" value="15" min="1" max="30"/></div>
         <div class="flex items-center"><input type="checkbox" id="showMarkers" name="showMarkers" checked /><label for="showMarkers">Show Markers</label></div>
+        <div class="flex items-center"><input type="checkbox" id="onlyTrace" name="onlyTrace" /><label for="onlyTrace">Only show where you've been</label></div>
         `;
 
         // Prevent map drag when clicking control

--- a/frontend/src/views/user/heatmap.js
+++ b/frontend/src/views/user/heatmap.js
@@ -62,9 +62,58 @@ class WtHeatmap extends HTMLElement {
       })
       .addTo(map);
 
+    let heatLayer = null;
+    let heatMapData = null;
+    let markers = null;
+    const rerenderHeatMap = () => {
+      if (heatMapData === null || markers === null) {
+        console.log("data not ready")
+        return
+      }
+      if (heatLayer !== null) {
+        map.removeLayer(heatLayer);
+      }
+      const radius = L.DomUtil.get("radius").value;
+      const blur = L.DomUtil.get("blur").value;
+      const showMarkers = L.DomUtil.get("showMarkers").checked;
+      heatLayer = L.heatLayer(heatMapData, { radius: Number(radius), blur: Number(blur) })
+      heatLayer.addTo(map);
+      if (showMarkers) {
+        markers.addTo(map);
+      } else {
+        markers.removeFrom(map);
+      }
+    }
+
+    let customControl = L.Control.extend({
+      options: { position: 'topright' },
+
+      onAdd: function () {
+        const container = L.DomUtil.create('div', 'flex flex-col p-2');
+
+        container.style.backgroundColor = 'white';
+        container.innerHTML = `
+        <div class="flex items-center"><label for="radius" class="w-12">Radius </label><input class="p-0" type="range" id="radius" value="10" min="5" max="30"/></div>
+        <div class="flex items-center"><label for="blur" class="w-12">Blur </label><input class="p-0" type="range" id="blur" value="15" min="5" max="30"/></div>
+        <div class="flex items-center"><input type="checkbox" id="showMarkers" name="showMarkers" checked /><label for="showMarkers">Show Markers</label></div>
+        `;
+
+        // Prevent map drag when clicking control
+        L.DomEvent.disableClickPropagation(container);
+
+        container.querySelectorAll("input")
+          .forEach((element) => {
+            element.oninput = L.Util.throttle(rerenderHeatMap, 50);
+          })
+
+        return container;
+      }
+    });
+
+    map.addControl(new customControl());
+
     layerStreet.addTo(map);
 
-    var heatConfig = { radius: 10 };
     var clusterConfig = { showCoverageOnHover: false };
 
     fetch(this.apiWorkoutsCoordinatesRoute, {
@@ -75,8 +124,8 @@ class WtHeatmap extends HTMLElement {
     })
       .then((response) => response.json())
       .then((response) => {
-        var data = geoJson2heat(response.results);
-        L.heatLayer(data, heatConfig).addTo(map);
+        heatMapData = geoJson2heat(response.results);
+        rerenderHeatMap();
       });
 
     fetch(this.apiWorkoutsCentersRoute, {
@@ -87,8 +136,8 @@ class WtHeatmap extends HTMLElement {
     })
       .then((response) => response.json())
       .then((response) => {
-        var markers = L.markerClusterGroup(clusterConfig);
-        var geoJsonLayer = L.geoJson(response.results, {
+        markers = L.markerClusterGroup(clusterConfig);
+        const geoJsonLayer = L.geoJson(response.results, {
           onEachFeature: function (feature, layer) {
             layer.bindPopup(feature.properties.details);
           },

--- a/frontend/src/views/user/heatmap.js
+++ b/frontend/src/views/user/heatmap.js
@@ -67,8 +67,7 @@ class WtHeatmap extends HTMLElement {
     let markers = null;
     const rerenderHeatMap = () => {
       if (heatMapData === null || markers === null) {
-        console.log("data not ready")
-        return
+        return;
       }
       if (heatLayer !== null) {
         map.removeLayer(heatLayer);
@@ -76,22 +75,25 @@ class WtHeatmap extends HTMLElement {
       const radius = L.DomUtil.get("radius").value;
       const blur = L.DomUtil.get("blur").value;
       const showMarkers = L.DomUtil.get("showMarkers").checked;
-      heatLayer = L.heatLayer(heatMapData, { radius: Number(radius), blur: Number(blur) })
+      heatLayer = L.heatLayer(heatMapData, {
+        radius: Number(radius),
+        blur: Number(blur),
+      });
       heatLayer.addTo(map);
       if (showMarkers) {
         markers.addTo(map);
       } else {
         markers.removeFrom(map);
       }
-    }
+    };
 
     let customControl = L.Control.extend({
-      options: { position: 'topright' },
+      options: { position: "topright" },
 
       onAdd: function () {
-        const container = L.DomUtil.create('div', 'flex flex-col p-2');
+        const container = L.DomUtil.create("div", "flex flex-col p-2");
 
-        container.style.backgroundColor = 'white';
+        container.style.backgroundColor = "white";
         container.innerHTML = `
         <div class="flex items-center"><label for="radius" class="w-12">Radius </label><input class="p-0" type="range" id="radius" value="10" min="5" max="30"/></div>
         <div class="flex items-center"><label for="blur" class="w-12">Blur </label><input class="p-0" type="range" id="blur" value="15" min="5" max="30"/></div>
@@ -101,13 +103,12 @@ class WtHeatmap extends HTMLElement {
         // Prevent map drag when clicking control
         L.DomEvent.disableClickPropagation(container);
 
-        container.querySelectorAll("input")
-          .forEach((element) => {
-            element.oninput = L.Util.throttle(rerenderHeatMap, 50);
-          })
+        container.querySelectorAll("input").forEach((element) => {
+          element.oninput = L.Util.throttle(rerenderHeatMap, 50);
+        });
 
         return container;
-      }
+      },
     });
 
     map.addControl(new customControl());


### PR DESCRIPTION
Added a custom control in leaflet so that user can control the radius and blur in heatmap. Also whether to show markers.

With default settings:
<img width="2210" height="1225" alt="image" src="https://github.com/user-attachments/assets/0df20adb-c50d-4400-a538-80d5ccbcda2b" />

User can change them:
<img width="2210" height="1223" alt="image" src="https://github.com/user-attachments/assets/1a1fb551-92aa-4815-a672-f9a169ace1ed" />
