### PR TITLE
fix(user-registration): Make sure user can not register as admin / active

### DIFF
--- a/pkg/app/users_handlers.go
+++ b/pkg/app/users_handlers.go
@@ -78,6 +78,9 @@ func (a *App) userRegisterHandler(c echo.Context) error {
 	u.Profile.Theme = BrowserTheme
 	u.Profile.TotalsShow = DefaultTotalsShow
 	u.Profile.Language = BrowserLanguage
+	// ensure user is not admin and not active by default
+	u.Admin = false
+	u.Active = false
 
 	if err := u.Create(a.db); err != nil {
 		return a.redirectWithError(c, a.echo.Reverse("user-login"), err)

--- a/views/workouts/show.templ
+++ b/views/workouts/show.templ
@@ -82,7 +82,7 @@ templ Show(w *database.Workout) {
 			}
 		</div>
 		if w.Details() != nil {
-			<div class="inner-form h-[300px] md:h-[500px] print:hidden">
+			<div class="inner-form h-[500px] print:hidden">
 				<h3>
 					<span>
 						@helpers.IconFor("speed")

--- a/views/workouts/show_templ.go
+++ b/views/workouts/show_templ.go
@@ -223,7 +223,7 @@ func Show(w *database.Workout) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if w.Details() != nil {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div class=\"inner-form h-[300px] md:h-[500px] print:hidden\"><h3><span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div class=\"inner-form h-[500px] print:hidden\"><h3><span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}


### PR DESCRIPTION
This ensures a bug in marshalling, form, etc. can not allow a user to
register directly as an admin, or activate their account during
registration.

Also:

fix(ui): Keep the workout graph at 500px

This keeps the graph at 500px, removing a glitch in the UI on small
screens.

Fixes: #614

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>