### PR TITLE
feat(secrets): Add support for reading secrets from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ docker run -p 8080:8080 \
     ghcr.io/jovandeginste/workout-tracker:master
 ```
 
+or read the JWT encryption key from a file:
+
+```bash
+docker run -p 8080:8080 \
+    -e WT_JWT_ENCRYPTION_KEY_FILE=/run/secrets/jwt_encryption_key.txt \
+    -v $PWD/jwt_encryption_key.txt:/run/secrets/jwt_encryption_key.txt \
+    -v $PWD/data:/data \
+    ghcr.io/jovandeginste/workout-tracker:master
+```
+
 or use docker compose
 
 ```bash
@@ -132,6 +142,14 @@ To persist sessions, run:
 
 ```bash
 export WT_JWT_ENCRYPTION_KEY=my-secret-key
+./workout-tracker
+```
+
+or read the JWT encryption key from a file:
+
+```bash
+echo "my-secret-key" > ./jwt_encryption_key.txt
+export WT_JWT_ENCRYPTION_KEY_FILE=./jwt_encryption_key.txt
 ./workout-tracker
 ```
 
@@ -256,7 +274,8 @@ current sessions.
 Generate a secure key and write it to `workout-tracker.yaml`:
 
 ```bash
-echo "jwt_encryption_key: $(pwgen -c 32)" > workout-tracker.yaml
+echo "jwt_encryption_key_file: ./jwt_encryption_key.txt" > ./workout-tracker.yaml
+pwgen -c 32 > ./jwt_encryption_key.txt
 ```
 
 or export it as an environment variable:

--- a/docker/docker-compose.base.yaml
+++ b/docker/docker-compose.base.yaml
@@ -8,7 +8,9 @@ services:
     networks:
       - workout-tracker
     environment:
-      - WT_JWT_ENCRYPTION_KEY=my-secret-key
+      - WT_JWT_ENCRYPTION_KEY_FILE=/run/secrets/jwt_encryption_key
+    secrets:
+      - jwt_encryption_key
   db:
     image: postgres:16-alpine
     container_name: wt-db

--- a/docker/docker-compose.dev.postgres.yaml
+++ b/docker/docker-compose.dev.postgres.yaml
@@ -28,3 +28,7 @@ volumes:
 networks:
   workout-tracker:
     external: false
+
+secrets:
+  jwt_encryption_key:
+    file: ./jwt_encryption_key.txt

--- a/docker/docker-compose.dev.sqlite.yaml
+++ b/docker/docker-compose.dev.sqlite.yaml
@@ -19,3 +19,7 @@ volumes:
 networks:
   workout-tracker:
     external: false
+
+secrets:
+  jwt_encryption_key:
+    file: ./jwt_encryption_key.txt

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -31,4 +31,3 @@ services:
       - ../translations:/app/translations
     environment:
       - APP_ENV=development
-      - WT_JWT_ENCRYPTION_KEY=dev-secret-key

--- a/docker/docker-compose.postgres.yaml
+++ b/docker/docker-compose.postgres.yaml
@@ -19,3 +19,7 @@ services:
 networks:
   workout-tracker:
     external: false
+
+secrets:
+  jwt_encryption_key:
+    file: ./jwt_encryption_key.txt

--- a/docker/docker-compose.sqlite.yaml
+++ b/docker/docker-compose.sqlite.yaml
@@ -10,3 +10,7 @@ services:
 networks:
   workout-tracker:
     external: false
+
+secrets:
+  jwt_encryption_key:
+    file: ./jwt_encryption_key.txt

--- a/docker/jwt_encryption_key.txt
+++ b/docker/jwt_encryption_key.txt
@@ -1,0 +1,1 @@
+my-secret-key

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"os"
+	"strings"
+
 	"github.com/spf13/viper"
 )
 
@@ -22,10 +25,12 @@ func (a *App) ReadConfiguration() error {
 		"bind",
 		"web_root",
 		"jwt_encryption_key",
+		"jwt_encryption_key_file",
 		"logging",
 		"debug",
 		"database_driver",
 		"dsn",
+		"dsn_file",
 		"registration_disabled",
 		"socials_disabled",
 	} {
@@ -53,4 +58,24 @@ func (a *App) ResetConfiguration() error {
 	}
 
 	return a.Config.UpdateFromDatabase(a.db)
+}
+
+func (a *App) SetDSN() {
+	if a.Config.DSN != "" {
+		return
+	}
+
+	if a.Config.DSNFile == "" {
+		return
+	}
+
+	a.logger.Info("reading DSNFile", "file", a.Config.DSNFile)
+
+	dsn, err := os.ReadFile(a.Config.DSNFile)
+	if err != nil {
+		a.logger.Error("could not read DSN file", "error", err)
+		return
+	}
+
+	a.Config.DSN = strings.TrimSpace(string(dsn))
 }

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -31,6 +31,9 @@ type EnvConfig struct {
 	DSN              string `mapstructure:"dsn" gorm:"-"`                // Database DSN
 	Logging          bool   `mapstructure:"logging" gorm:"-"`            // Enable logging
 	Debug            bool   `mapstructure:"debug" gorm:"-"`              // Debug logging mode
+
+	JWTEncryptionKeyFile string `mapstructure:"jwt_encryption_key_file" gorm:"-"` // File containing the encryption key for JWT
+	DSNFile              string `mapstructure:"dsn_file" gorm:"-"`                // File containing the database DSN
 }
 
 func getConfig(db *gorm.DB) (*Config, error) {

--- a/workout-tracker.example.yaml
+++ b/workout-tracker.example.yaml
@@ -1,5 +1,8 @@
 # This is the key that signs JWT tokens
 jwt_encryption_key: some_long_random_string
+# or read the JWT encryption key from a file
+jwt_encryption_key_file: /path/to/jwt_encryption_key.txt
+
 # Enables debug output in both the web and database server
 debug: false
 # Which host and port to bind on


### PR DESCRIPTION
Following conventions to not store secrets in configuration files or
exporting them in environment variables.

See also: https://docs.docker.com/compose/how-tos/use-secrets/

Fixes: #644

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>