### PR TITLE
fix(database): Correct workout average update and map detail saving

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -573,7 +573,7 @@ func (w *Workout) save(db *gorm.DB) error {
 		return ErrInvalidData
 	}
 
-	if !w.HasFile() {
+	if w.HasFile() {
 		w.UpdateAverages()
 	}
 

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -190,8 +190,10 @@ func shouldAddState(address *geo.Address) bool {
 }
 
 func (m *MapData) Save(db *gorm.DB) error {
-	if err := db.Save(m.Details).Error; err != nil {
-		return err
+	if m.Details != nil {
+		if err := db.Save(m.Details).Error; err != nil {
+			return err
+		}
 	}
 
 	return db.Save(m).Error


### PR DESCRIPTION
Change the condition for updating workout averages for a workout. Previously,
averages were updated only when a workout did not have an associated file. This
was incorrect, as averages should only be calculated and updated when there is
actual file data (e.g., GPS data) present to average. This correction ensures
that `UpdateAverages` is called only when meaningful data exists.

Add a nil check before attempting to save `MapData.Details`. `m.Details` can be
nil in some cases, and attempting to save a nil pointer with GORM can lead to
errors or unexpected behavior. This change ensures that `db.Save(m.Details)` is
only executed if `m.Details` is a valid (non-nil) object, improving the
robustness of the `MapData` persistence.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
