### PR TITLE
feat(i18n): Add Spanish (es) localization

### DIFF
--- a/frontend/lit-localize.json
+++ b/frontend/lit-localize.json
@@ -3,6 +3,7 @@
   "sourceLocale": "en",
   "targetLocales": [
     "de",
+    "es",
     "fa",
     "fi",
     "fr",

--- a/frontend/src/locale.ts
+++ b/frontend/src/locale.ts
@@ -8,6 +8,7 @@ export function initLocalize() {
     loadLocale: (locale) =>
       ({
         de: () => import("./generated/locales/de"),
+        es: () => import("./generated/locales/es"),
         fa: () => import("./generated/locales/fa"),
         fi: () => import("./generated/locales/fi"),
         fr: () => import("./generated/locales/fr"),

--- a/frontend/xliff/es.xlf
+++ b/frontend/xliff/es.xlf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="es" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="translation.Average_speed">
+  <source>Average speed</source>
+</trans-unit>
+<trans-unit id="translation.Elevation">
+  <source>Elevation</source>
+</trans-unit>
+<trans-unit id="translation.Tempo">
+  <source>Tempo</source>
+</trans-unit>
+<trans-unit id="translation.Total_up">
+  <source>Total up</source>
+</trans-unit>
+<trans-unit id="translation.Total_down">
+  <source>Total down</source>
+</trans-unit>
+<trans-unit id="translation.Breakdown">
+  <source>Breakdown</source>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -1,32 +1,33 @@
-alerts:
-  something_wrong: 'Algo ha salido mal: %{message}'
-  workouts_added:
-    one: 'Se ha encontrado un problema al añadir el entrenamiento: %{list}'
-    many: 'Se han encontrado %{count} problemas al añadir el entrenamiento: %{list}'
-    other: Se encontraron problemas al añadir el entrenamiento
-  route_segments_added:
-    one: 'Se ha encontrado un problema mientras añadiamos un segmento: %{list}'
-    many: 'Se han encontrado problemas mientras añadiamos un segmento: %{list}'
-    other: 'Se han encontrado %{count} problemas mientras añadiamos un segmento: %{list}'
-notices:
-  workouts_added:
-    one: 'Añadido nuevo entrenamiento: %{list}'
-    many: Se han añadido los entrenamientos
-    other: 'Se han añadido %{count} nuevos entrenamientos: %{list}'
-misc:
-  month_1: 1 mes
-  years_1: 1 año
-  years_10: 10 años
-  day_15: 15 dias
-  years_2: 2 años
-  month_3: 3 meses
-  years_5: 5 años
-  month_6: 6 meses
-  day_7: 7 dias
-  forever: Siempre
-  day: dia
-  month: mes
-  equipment: equipamiento
-  route_segment: segmento
-  workout: entrenamiento
-  split_files_with_multiple_tracks: dividir archivos en múltiples tracks
+es:
+  alerts:
+    something_wrong: 'Algo ha salido mal: %{message}'
+    workouts_added:
+      one: 'Se ha encontrado un problema al añadir el entrenamiento: %{list}'
+      many: 'Se han encontrado %{count} problemas al añadir el entrenamiento: %{list}'
+      other: Se encontraron problemas al añadir el entrenamiento
+    route_segments_added:
+      one: 'Se ha encontrado un problema mientras añadiamos un segmento: %{list}'
+      many: 'Se han encontrado problemas mientras añadiamos un segmento: %{list}'
+      other: 'Se han encontrado %{count} problemas mientras añadiamos un segmento: %{list}'
+  notices:
+    workouts_added:
+      one: 'Añadido nuevo entrenamiento: %{list}'
+      many: Se han añadido los entrenamientos
+      other: 'Se han añadido %{count} nuevos entrenamientos: %{list}'
+  misc:
+    month_1: 1 mes
+    years_1: 1 año
+    years_10: 10 años
+    day_15: 15 dias
+    years_2: 2 años
+    month_3: 3 meses
+    years_5: 5 años
+    month_6: 6 meses
+    day_7: 7 dias
+    forever: Siempre
+    day: dia
+    month: mes
+    equipment: equipamiento
+    route_segment: segmento
+    workout: entrenamiento
+    split_files_with_multiple_tracks: dividir archivos en múltiples tracks

--- a/views/helpers/language.go
+++ b/views/helpers/language.go
@@ -31,6 +31,7 @@ var (
 		language.Polish,
 		language.Russian,
 		language.SimplifiedChinese,
+		language.Spanish,
 		language.Turkish,
 	}
 )


### PR DESCRIPTION
Add Spanish as a supported localization across the application.

- Enable Spanish in Lit Localize by adding "es" to `lit-localize.json` and updating the dynamic import map in `frontend/src/locale.ts`. This allows the frontend to load and use Spanish translations.
- Introduce `frontend/xliff/es.xlf` which will contain the actual translations for Lit Localize strings, generated by the localization tool.
- Wrap the existing Spanish translations in `translations/es.yaml` under a top-level `es` key. This standardizes the YAML structure to match other language files and improve consistency.
- Register `language.Spanish` in `views/helpers/language.go` to ensure the backend recognizes and supports Spanish for content negotiation and rendering.