### PR TITLE
fix(workouts) fix workouts uploaded from zip file cannot be updated

### DIFF
--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -366,6 +366,7 @@ func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string,
 			Date:   *d,
 		}
 
+		// If multiple GPX files are extracted (e.g., from a zip), use the individual GPX filename.
 		if filename == "" || len(gpxContent) > 1 {
 			filename = g.Filename()
 		}

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -366,7 +366,7 @@ func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string,
 			Date:   *d,
 		}
 
-		if filename == "" {
+		if filename == "" || len(gpxContent) > 1 {
 			filename = g.Filename()
 		}
 


### PR DESCRIPTION
When trying to update workouts uploaded with a zip file workout updates are failing because the filename of the individual workouts is the name auf the original zip file causing the worker to use the wrong parser. 