### PR TITLE
fix(workout): fix fit file workout name date empty

### DIFF
--- a/pkg/converters/fit.go
+++ b/pkg/converters/fit.go
@@ -28,7 +28,12 @@ func ParseFit(content []byte) (*gpx.GPX, error) {
 		return nil, errors.New("no sessions found")
 	}
 
-	name := act.Sessions[0].Sport.String() + " - " + act.Activity.LocalTimestamp.Format(time.DateTime)
+	activityTime := act.Activity.LocalTimestamp
+	if activityTime.IsZero() {
+		activityTime = act.Sessions[0].StartTime.Local()
+	}
+
+	name := act.Sessions[0].Sport.String() + " - " + activityTime.Format(time.DateTime)
 	gpxFile := &gpx.GPX{
 		Name:    name,
 		Time:    &act.FileId.TimeCreated,


### PR DESCRIPTION
In fit files the activity field `LocalTimestamp` is not always set (for example Hammerhead Karoo produces such outputs) resulting in workouts getting named e.g. `cycling - 0001-01-01 00:00:00`. 

I added a fallback to the start time of the session. 