### PR TITLE
feat(geocoder): Add offline mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,13 @@ WT_REGISTRATION_DISABLED="false"
 WT_SOCIALS_DISABLED="false"
 WT_DEV="false"
 WT_WORKER_DELAY_SECONDS=60
+WT_OFFLINE="false"
 ```
+
+> [!NOTE]  
+> Setting `WT_OFFLINE` to `true` runs the app without making external geocoding
+> requests (useful for offline environments or to avoid rate limits). In this
+> mode, geocoding functions return nil results.
 
 After starting the server, you can access it at <http://localhost:8080> (the
 default port). A login form is shown.

--- a/cmd/wt-debug/cli.go
+++ b/cmd/wt-debug/cli.go
@@ -33,9 +33,7 @@ func newCLI() (*cli, error) {
 		return nil, err
 	}
 
-	if err := a.ConfigureGeocoder(); err != nil {
-		return nil, err
-	}
+	a.ConfigureGeocoder()
 
 	c := &cli{
 		app: a,

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -82,9 +82,7 @@ func (a *App) Configure() error {
 		return err
 	}
 
-	if err := a.ConfigureGeocoder(); err != nil {
-		return err
-	}
+	a.ConfigureGeocoder()
 
 	if err := a.Config.UpdateFromDatabase(a.db); err != nil {
 		return err
@@ -97,9 +95,13 @@ func (a *App) Configure() error {
 	return nil
 }
 
-func (a *App) ConfigureGeocoder() error {
+func (a *App) ConfigureGeocoder() {
+	if a.Config.Offline {
+		geocoder.ForceOffline()
+		return
+	}
+
 	geocoder.SetClient(a.logger, a.Version.UserAgent())
-	return nil
 }
 
 func (a *App) ConfigureDatabase() error {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -16,6 +16,7 @@ func (a *App) ReadConfiguration() error {
 	viper.SetDefault("web_root", "")
 	viper.SetDefault("logging", true)
 	viper.SetDefault("debug", false)
+	viper.SetDefault("offline", false)
 	viper.SetDefault("database_driver", "sqlite")
 	viper.SetDefault("dsn", "./database.db")
 	viper.SetDefault("registration_disabled", false)
@@ -28,6 +29,7 @@ func (a *App) ReadConfiguration() error {
 		"jwt_encryption_key",
 		"jwt_encryption_key_file",
 		"logging",
+		"offline",
 		"debug",
 		"database_driver",
 		"dsn",

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -31,6 +31,7 @@ type EnvConfig struct {
 	DSN                string `mapstructure:"dsn" gorm:"-"`                  // Database DSN
 	Logging            bool   `mapstructure:"logging" gorm:"-"`              // Enable logging
 	Debug              bool   `mapstructure:"debug" gorm:"-"`                // Debug logging mode
+	Offline            bool   `mapstructure:"offline" gorm:"-"`              // Disable calls to external services
 	WorkerDelaySeconds int    `mapstructure:"worker_delay_seconds" gorm:"-"` // Time in seconds between worker runs
 
 	JWTEncryptionKeyFile string `mapstructure:"jwt_encryption_key_file" gorm:"-"` // File containing the encryption key for JWT

--- a/pkg/database/user_test.go
+++ b/pkg/database/user_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() { //nolint:gochecknoinits
-	online = false
+	goOffline()
 }
 
 func defaultUser() *User {

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -17,8 +17,6 @@ import (
 	"gorm.io/gorm"
 )
 
-var online = true
-
 const UnknownLocation = "(unknown location)"
 
 var correctAltitudeCreators = []string{
@@ -270,7 +268,7 @@ func (m *MapCenter) IsZero() bool {
 }
 
 func (m *MapCenter) Address() *geo.Address {
-	if !online || m.IsZero() {
+	if m.IsZero() {
 		return nil
 	}
 

--- a/pkg/database/workouts_test.go
+++ b/pkg/database/workouts_test.go
@@ -3,12 +3,17 @@ package database
 import (
 	"testing"
 
+	"github.com/jovandeginste/workout-tracker/v2/pkg/geocoder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func init() { //nolint:gochecknoinits
-	online = false
+	goOffline()
+}
+
+func goOffline() {
+	geocoder.ForceOffline()
 }
 
 func defaultWorkout(t *testing.T) *Workout {


### PR DESCRIPTION
Introduce a new `offline` configuration option to allow the application to run
without making calls to external services (eg. geocoding). This provides a way
to operate in environments with no internet access or to avoid rate limits.

The `ConfigureGeocoder` function in the application now checks the `Offline`
configuration flag. If set to true, it explicitly configures the geocoder
package into an offline state, preventing any network requests. If false, it
proceeds to set up the online geocoder client. This change also removes the
error return from `ConfigureGeocoder`, as running in offline mode is now a valid
operational state, not an error condition that should halt application startup.

The geocoder package now centralizes its offline logic. A new `Offline()`
function sets an internal `offline` flag within the geocoder client. The
`search` and `Reverse` functions now check this flag and immediately return nil
results if the geocoder is in offline mode, eliminating external HTTP calls.

Testing utilities and internal database modules have been updated to utilize
this new centralized geocoder offline mechanism. The redundant package-level
`online` flag has been removed from the `database` package, simplifying logic in
methods like `MapCenter.Address()` and consolidating the control of
online/offline behavior.

Fixes #679

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
