### PR TITLE
build: let Git handle line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Without this setting and running inside a Linux dev container on a Windows machine (using WSL2), Git reports many changed files after executing `make build-server` inside the dev container - the only differences are the line-endings, i.e. LF vs. CRLF. By using a `.gitattributes` file `* text=auto`, Git will handle line-endings for us.