### PR TITLE
refactor(database): Defer metric and address updates until `UpdateData`

### DIFF
--- a/pkg/database/user_test.go
+++ b/pkg/database/user_test.go
@@ -350,6 +350,7 @@ func TestDatabaseUserWorkouts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, workouts, 1)
 
+	w2_1.UpdateExtraMetrics()
 	assert.True(t, w2_1.HasElevation())
 	assert.True(t, w2_1.HasHeartRate())
 

--- a/pkg/database/workouts.go
+++ b/pkg/database/workouts.go
@@ -372,8 +372,6 @@ func NewWorkout(u *User, workoutType WorkoutType, notes string, filename string,
 		}
 
 		w.setContent(filename, g.Content)
-		w.UpdateAverages()
-		w.UpdateExtraMetrics()
 
 		workouts[i] = w
 	}
@@ -574,10 +572,6 @@ func (w *Workout) save(db *gorm.DB) error {
 		return ErrInvalidData
 	}
 
-	if w.HasFile() {
-		w.UpdateAverages()
-	}
-
 	if w.ID == 0 {
 		if err := db.Save(w).Error; err != nil {
 			return err
@@ -638,10 +632,7 @@ func (w *Workout) setData(data *MapData) {
 		data.Address = w.Data.Address
 	}
 
-	data.UpdateAddress()
-	data.UpdateExtraMetrics()
 	data.CalculateSlopes()
-	data.correctNaN()
 
 	w.Data = data
 }
@@ -726,6 +717,7 @@ func (w *Workout) UpdateData(db *gorm.DB) error {
 
 	w.UpdateAverages()
 	w.UpdateExtraMetrics()
+	w.Data.UpdateAddress()
 	w.Dirty = false
 
 	return w.Save(db)

--- a/pkg/database/workouts_map.go
+++ b/pkg/database/workouts_map.go
@@ -411,8 +411,6 @@ func createMapData(gpxContent *gpx.GPX) *MapData {
 		},
 	}
 
-	data.UpdateAddress()
-	data.UpdateExtraMetrics()
 	data.correctNaN()
 
 	return data


### PR DESCRIPTION
Remove calls to `UpdateExtraMetrics`, `UpdateAverages`, and `UpdateAddress`
inside `NewWorkout`, `Workout.save`, and `createMapData`.

Metrics (like averages) are now only calculated when `Workout.UpdateData` is
explicitly called. This simplifies the flow and ensures that full data
processing happens in a single, predictable location (`UpdateData`), which is
typically triggered in a background worker pool.

`Workout.UpdateData` now calls `w.Data.UpdateAddress()` to ensure the workout's
address is resolved when updating its data.

May fix #680

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
