### PR TITLE
fix(database): Correct slope percentage checks for climb categories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,13 @@ build-server:
 
 build-docker:
 	docker build \
-			-t workout-tracker --pull \
+			--tag workout-tracker --pull \
 			--build-arg BUILD_TIME="$(BUILD_TIME)" \
 			--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 			--build-arg GIT_REF="$(GIT_REF)" \
 			--build-arg GIT_REF_NAME="$(GIT_REF_NAME)" \
 			--build-arg GIT_REF_TYPE="$(GIT_REF_TYPE)" \
+			--file ./docker/Dockerfile \
 			.
 
 swagger:

--- a/pkg/database/workouts_slope.go
+++ b/pkg/database/workouts_slope.go
@@ -242,19 +242,19 @@ func (d *Detector) validateAndAppendSegment(segmentPoints []*MapPoint) {
 
 func ClassifyClimbCategory(length, slope float64) string {
 	switch {
-	case length >= 10000 && slope >= 6:
+	case length >= 10000 && slope >= 0.06:
 		return "Hors Catégorie"
-	case length >= 8000 && slope >= 5:
+	case length >= 8000 && slope >= 0.05:
 		return "Category 1"
-	case length >= 5000 && slope >= 4:
+	case length >= 5000 && slope >= 0.04:
 		return "Category 2"
-	case length >= 3000 && slope >= 3:
+	case length >= 3000 && slope >= 0.03:
 		return "Category 3"
-	case length >= 2000 && slope >= 3:
+	case length >= 2000 && slope >= 0.03:
 		return "Category 4"
-	case length >= 1000 && slope >= 2:
+	case length >= 1000 && slope >= 0.02:
 		return "Category 5"
-	case length >= 500 && slope >= 1:
+	case length >= 500 && slope >= 0.01:
 		return "Category 6"
 	default:
 		return "Uncategorized"


### PR DESCRIPTION
Update ClassifyClimbCategory to use decimal representations for slope thresholds
(e.g., 0.06 instead of 6).

The function previously compared the calculated slope (likely a ratio or
decimal) against integer values representing percentages, leading to incorrect
climb classification logic. The comparison values now correctly reflect the
required percentage slopes (1% to 6%) as decimals.

chore(build): Explicitly define Dockerfile path in Makefile

Specify the Dockerfile location using `--file ./docker/Dockerfile` in the
`build-docker` target for clarity. Also switches the short form `-t` to the long
form `--tag`.
