### PR TITLE
fix(climb): Fix average climb slope rendering

### DIFF
--- a/views/workouts/show.templ
+++ b/views/workouts/show.templ
@@ -3,9 +3,9 @@ package workouts
 import (
 	"github.com/invopop/ctxi18n/i18n"
 	"github.com/jovandeginste/workout-tracker/v2/pkg/database"
-	"github.com/jovandeginste/workout-tracker/v2/pkg/templatehelpers"
 	"github.com/jovandeginste/workout-tracker/v2/views/helpers"
 	"github.com/jovandeginste/workout-tracker/v2/views/partials"
+	"math"
 )
 
 templ Show(w *database.Workout) {
@@ -150,7 +150,7 @@ templ renderClimbs(w *database.Workout) {
 						<td>{ helpers.HumanDistance(ctx, climb.Length) } { pu.Distance() }</td>
 						<td>{ helpers.HumanDuration(climb.Duration) }</td>
 						<td class="hidden lg:table-cell">{ helpers.HumanElevation(ctx, climb.Elevation) } { pu.Elevation() }</td>
-						<td>{ templatehelpers.RoundFloat64(climb.AvgSlope) }%</td>
+						<td>{ math.Round(100*climb.AvgSlope) } %</td>
 						<td class="hidden sm:table-cell">{ climb.Category }</td>
 					</tr>
 				}

--- a/views/workouts/show_templ.go
+++ b/views/workouts/show_templ.go
@@ -11,9 +11,9 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"github.com/invopop/ctxi18n/i18n"
 	"github.com/jovandeginste/workout-tracker/v2/pkg/database"
-	"github.com/jovandeginste/workout-tracker/v2/pkg/templatehelpers"
 	"github.com/jovandeginste/workout-tracker/v2/views/helpers"
 	"github.com/jovandeginste/workout-tracker/v2/views/partials"
+	"math"
 )
 
 func Show(w *database.Workout) templ.Component {
@@ -588,15 +588,15 @@ func renderClimbs(w *database.Workout) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(templatehelpers.RoundFloat64(climb.AvgSlope))
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(math.Round(100 * climb.AvgSlope))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/workouts/show.templ`, Line: 153, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/workouts/show.templ`, Line: 153, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "%</td><td class=\"hidden sm:table-cell\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " %</td><td class=\"hidden sm:table-cell\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Calculate the average slope percentage by multiplying the ratio by 100 and
rounding it inside the workout show template. This provides a clean integer
percentage display for climbs.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
