### PR TITLE
chore(release): Update CI to use unified frontend build target

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: make install-deps
 
-      - name: Build Tailwind CSS output
-        run: make build-dist build-tw
+      - name: Build frontend
+        run: make build-frontend
 
       - uses: wangyoucao577/go-release-action@v1
         with:


### PR DESCRIPTION
Replace explicit make targets (`build-dist build-tw`) with the consolidated
`build-frontend` target in the release workflow configuration.

The old targets were removed when reworking the whole frontend part.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
