### PR TITLE
feat(health): Implement application and container health checks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ RUN apk --no-cache add make
 WORKDIR /app
 
 COPY frontend ./frontend
-RUN cd frontend && \
-  npm ci
+RUN cd frontend \
+    && npm ci
 
 COPY Makefile ./
 COPY assets ./assets
@@ -37,15 +37,16 @@ COPY --from=frontend /app/assets ./assets
 
 ENV CGO_ENABLED=0
 RUN go build \
-  -ldflags "-X 'main.buildTime=${BUILD_TIME}' -X 'main.gitCommit=${GIT_COMMIT}' -X 'main.gitRef=${GIT_REF}' -X 'main.gitRefName=${GIT_REF_NAME}' -X 'main.gitRefType=${GIT_REF_TYPE}'" \
-  -o /commands/ ./cmd/...
+    -ldflags "-X 'main.buildTime=${BUILD_TIME}' -X 'main.gitCommit=${GIT_COMMIT}' -X 'main.gitRef=${GIT_REF}' -X 'main.gitRefName=${GIT_REF_NAME}' -X 'main.gitRefType=${GIT_REF_TYPE}'" \
+    -o /commands/ ./cmd/...
 
 FROM alpine:3
 
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache tzdata curl
 COPY --from=backend /commands/* /app/
 
 VOLUME /data /imports
 WORKDIR /data
+HEALTHCHECK CMD curl -sSLf http://localhost:8080/health
 ENTRYPOINT ["/app/workout-tracker"]
 EXPOSE 8080

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -23,7 +23,7 @@ ARG GIT_REF
 ARG GIT_REF_NAME
 ARG GIT_REF_TYPE
 
-RUN apk --no-cache add make git
+RUN apk --no-cache add make git curl
 
 WORKDIR /app
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,6 +13,12 @@ services:
       WT_JWT_ENCRYPTION_KEY_FILE: /run/secrets/jwt_encryption_key
     secrets:
       - jwt_encryption_key
+    healthcheck:
+      test: ["CMD", "curl", "-sSLf", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   db-postgres:
     profiles:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/jovandeginste/workout-tracker/v2
 
 go 1.25
 
+toolchain go1.25.3
+
 replace github.com/anyappinc/fitbit v0.0.3 => github.com/jovandeginste/fitbit v0.0.4-0.20250213164811-b0b3b27c3a84
 
 require (
@@ -64,7 +66,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/a-h/parse v0.0.0-20250122154542-74294addb73e // indirect
-	github.com/air-verse/air v1.64.4 // indirect
+	github.com/air-verse/air v1.64.5 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bep/godartsass/v2 v2.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/a-h/parse v0.0.0-20250122154542-74294addb73e h1:HjVbSQHy+dnlS6C3XajZ6
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e/go.mod h1:3mnrkvGpurZ4ZrTDbYU84xhwXW2TjTKShSwjRi2ihfQ=
 github.com/a-h/templ v0.3.960 h1:trshEpGa8clF5cdI39iY4ZrZG8Z/QixyzEyUnA7feTM=
 github.com/a-h/templ v0.3.960/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
-github.com/air-verse/air v1.64.4 h1:P0alz5Jia5NucZew1HYZy69lzPWZHFjLTCKo0VhxME8=
-github.com/air-verse/air v1.64.4/go.mod h1:OaJZSfZqf7wyjS2oP/CcEVyIt0JmZuPh5x1gdtklmmY=
+github.com/air-verse/air v1.64.5 h1:+gs/NgTzYYe+gGPyfHy3XxpJReQWC1pIsiKIg0LgNt4=
+github.com/air-verse/air v1.64.5/go.mod h1:OaJZSfZqf7wyjS2oP/CcEVyIt0JmZuPh5x1gdtklmmY=
 github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=
 github.com/alecthomas/chroma/v2 v2.20.0/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
 github.com/alexedwards/scs/gormstore v0.0.0-20251002162104-209de6e426de h1:usfOUZAlDX38RyGTg2peETSD8e1TYf8qyr8G9zFPwTM=

--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -70,6 +70,11 @@ func (a *App) ConfigureWebserver() error {
 	})
 
 	publicGroup := e.Group(a.WebRoot())
+
+	publicGroup.GET("/health", func(c echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	}).Name = "health"
+
 	a.apiRoutes(publicGroup)
 
 	if a.AssetDir != "" {

--- a/pkg/app/routes_test.go
+++ b/pkg/app/routes_test.go
@@ -42,6 +42,21 @@ func defaultUser(db *gorm.DB) *database.User {
 	return u
 }
 
+func TestRoute_HealthCheck(t *testing.T) {
+	t.Run("should pass health check", func(t *testing.T) {
+		a := configuredApp(t)
+		e := a.echo
+
+		req := httptest.NewRequest(http.MethodGet, e.Reverse("health"), nil)
+		rec := httptest.NewRecorder()
+
+		a.echo.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "OK", rec.Body.String())
+	})
+}
+
 func TestRoute_UserRender(t *testing.T) {
 	t.Run("should render for the user", func(t *testing.T) {
 		a := configuredApp(t)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/a-h/templ/parser/v2/goexpression
 github.com/a-h/templ/parser/v2/visitor
 github.com/a-h/templ/runtime
 github.com/a-h/templ/safehtml
-# github.com/air-verse/air v1.64.4
+# github.com/air-verse/air v1.64.5
 ## explicit; go 1.25
 github.com/air-verse/air
 github.com/air-verse/air/runner


### PR DESCRIPTION
Add a new public HTTP GET route `/health` that returns a simple "OK" response
with HTTP 200.

Configure `HEALTHCHECK` instructions in the Dockerfile and detailed health check
parameters in the `docker-compose.yaml` file for documentation.

Fixes #735

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
