### PR TITLE
Fix collision of extra distance data

### DIFF
--- a/views/workouts/data-json.templ
+++ b/views/workouts/data-json.templ
@@ -25,7 +25,6 @@ func translationMap(ctx context.Context) map[string]string {
 		"cadence":      i18n.T(ctx, "translation.Cadence"),
 		"averagespeed": i18n.T(ctx, "translation.Average_speed"),
 		"slope":        i18n.T(ctx, "translation.Slope"),
-		"climb":        i18n.T(ctx, "translation.Climb"),
 	}
 }
 
@@ -37,7 +36,6 @@ func labelMap(ctx context.Context, w *database.Workout) map[string]*dataset {
 		"speed":    {Label: i18n.T(ctx, "translation.Speed"), Data: []any{}},
 		"duration": {Label: i18n.T(ctx, "translation.Duration"), Data: []any{}},
 		"slope":    {Label: i18n.T(ctx, "translation.Slope"), Data: []any{}},
-		"climb":    {Label: i18n.T(ctx, "translation.Climb"), Data: []any{}},
 	}
 
 	translations := translationMap(ctx)
@@ -71,7 +69,8 @@ func addDetails(ctx context.Context, data map[string]*dataset, w *database.Worko
 		data["speed"].Data = append(data["speed"].Data, cast.ToFloat64(helpers.HumanSpeed(ctx, s)))
 
 		for _, m := range w.Data.ExtraMetrics {
-			if m == "speed" {
+			switch m {
+			case "speed", "distance":
 				continue
 			}
 

--- a/views/workouts/data-json_templ.go
+++ b/views/workouts/data-json_templ.go
@@ -33,7 +33,6 @@ func translationMap(ctx context.Context) map[string]string {
 		"cadence":      i18n.T(ctx, "translation.Cadence"),
 		"averagespeed": i18n.T(ctx, "translation.Average_speed"),
 		"slope":        i18n.T(ctx, "translation.Slope"),
-		"climb":        i18n.T(ctx, "translation.Climb"),
 	}
 }
 
@@ -45,7 +44,6 @@ func labelMap(ctx context.Context, w *database.Workout) map[string]*dataset {
 		"speed":    {Label: i18n.T(ctx, "translation.Speed"), Data: []any{}},
 		"duration": {Label: i18n.T(ctx, "translation.Duration"), Data: []any{}},
 		"slope":    {Label: i18n.T(ctx, "translation.Slope"), Data: []any{}},
-		"climb":    {Label: i18n.T(ctx, "translation.Climb"), Data: []any{}},
 	}
 
 	translations := translationMap(ctx)
@@ -79,7 +77,8 @@ func addDetails(ctx context.Context, data map[string]*dataset, w *database.Worko
 		data["speed"].Data = append(data["speed"].Data, cast.ToFloat64(helpers.HumanSpeed(ctx, s)))
 
 		for _, m := range w.Data.ExtraMetrics {
-			if m == "speed" {
+			switch m {
+			case "speed", "distance":
 				continue
 			}
 


### PR DESCRIPTION
We don't want distance data from extra metrics to conflict with native
distance data.

Also remove the "climb" translation, since this is no longer used
(replaced with "slope")

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>