### PR TITLE
Filter nil-positions when drawing points on the map

### DIFF
--- a/frontend/src/components/map.js
+++ b/frontend/src/components/map.js
@@ -96,8 +96,11 @@ class WtMap extends HTMLElement {
 
     const elevationLayerGroup = new L.featureGroup();
 
-    const positions = this.workout.position.Data;
-    positions.forEach((p, i) => {
+    this.workout.position.Data.forEach((p, i) => {
+      if (p === null) {
+        return;
+      }
+
       if (prevPoint) {
         const elevation = this.workout.elevation.Data[i] || 0;
         // Add invisible point to map to allow fitBounds to work
@@ -133,40 +136,44 @@ class WtMap extends HTMLElement {
       elevationLayerGroup.addTo(map);
     }
 
-    let last = positions[positions.length - 1];
-    this.trackGroup.addLayer(
-      L.circleMarker(last, {
-        color: "red",
-        fill: true,
-        fillColor: "red",
-        fillOpacity: 1,
-        radius: 6,
-      })
-        .addTo(map)
-        .bindTooltip(this.getTooltip(positions.length - 1)),
-    );
+    const positions = this.workout.position.Data.filter((x) => x !== null);
 
-    let first = positions[0];
-    this.trackGroup.addLayer(
-      L.circleMarker(first, {
-        color: "green",
-        fill: true,
-        fillColor: "green",
-        fillOpacity: 1,
-        radius: 6,
-      })
-        .addTo(map)
-        .bindTooltip(this.getTooltip(0)),
-    );
+    if (positions.length > 0) {
+      let last = positions[positions.length - 1];
+      this.trackGroup.addLayer(
+        L.circleMarker(last, {
+          color: "red",
+          fill: true,
+          fillColor: "red",
+          fillOpacity: 1,
+          radius: 6,
+        })
+          .addTo(map)
+          .bindTooltip(this.getTooltip(positions.length - 1)),
+      );
 
-    if (!this.hoverMarker) {
-      this.hoverMarker = L.circleMarker(first, {
-        color: "blue",
-        radius: 8,
-      });
+      let first = positions[0];
+      this.trackGroup.addLayer(
+        L.circleMarker(first, {
+          color: "green",
+          fill: true,
+          fillColor: "green",
+          fillOpacity: 1,
+          radius: 6,
+        })
+          .addTo(map)
+          .bindTooltip(this.getTooltip(0)),
+      );
+
+      if (!this.hoverMarker) {
+        this.hoverMarker = L.circleMarker(first, {
+          color: "blue",
+          radius: 8,
+        });
+      }
+
+      this.hoverMarker.addTo(map); // Adding marker to the map
     }
-
-    this.hoverMarker.addTo(map); // Adding marker to the map
 
     const overlays = {
       [this.config.elevationName]: elevationLayerGroup,
@@ -215,7 +222,12 @@ class WtMap extends HTMLElement {
     const slopeLayerGroup = new L.featureGroup();
 
     let prevPoint;
-    this.workout.position.Data.forEach((p, i) => {
+    const positions = this.workout.position.Data;
+    positions.forEach((p, i) => {
+      if (p === null) {
+        return;
+      }
+
       if (prevPoint) {
         const slope = this.workout.slope.Data[i] || 0;
 
@@ -246,6 +258,9 @@ class WtMap extends HTMLElement {
 
     let prevPoint;
     this.workout.position.Data.forEach((p, i) => {
+      if (p === null) {
+        return;
+      }
       if (prevPoint) {
         const speed = this.workout.speed.Data[i] || null;
         if (speed === null || speed < 0.1) {
@@ -346,7 +361,11 @@ class WtMap extends HTMLElement {
   setSegment(_title, data) {
     this.segmentLayerGroup.clearLayers();
 
-    const positions = data["position"];
+    const positions = data.position.filter((p) => p !== null);
+    if (positions.length < 2) {
+      return;
+    }
+
     for (let i = 1; i < positions.length; i++) {
       L.polyline([positions[i - 1], positions[i]], {
         color: "red",

--- a/views/workouts/data-json.templ
+++ b/views/workouts/data-json.templ
@@ -61,7 +61,12 @@ func addDetails(ctx context.Context, data map[string]*dataset, w *database.Worko
 			s = p.AverageSpeed()
 		}
 
-		data["position"].Data = append(data["position"].Data, []float64{p.Lat, p.Lng})
+		if p.Lat != 0 || p.Lng != 0 {
+			data["position"].Data = append(data["position"].Data, []float64{p.Lat, p.Lng})
+		} else {
+			data["position"].Data = append(data["position"].Data, nil)
+		}
+
 		data["time"].Data = append(data["time"].Data, p.Time)
 		data["distance"].Data = append(data["distance"].Data, helpers.HumanDistance(ctx, p.TotalDistance))
 		data["duration"].Data = append(data["duration"].Data, p.TotalDuration.Seconds())

--- a/views/workouts/data-json_templ.go
+++ b/views/workouts/data-json_templ.go
@@ -69,7 +69,12 @@ func addDetails(ctx context.Context, data map[string]*dataset, w *database.Worko
 			s = p.AverageSpeed()
 		}
 
-		data["position"].Data = append(data["position"].Data, []float64{p.Lat, p.Lng})
+		if p.Lat != 0 || p.Lng != 0 {
+			data["position"].Data = append(data["position"].Data, []float64{p.Lat, p.Lng})
+		} else {
+			data["position"].Data = append(data["position"].Data, nil)
+		}
+
 		data["time"].Data = append(data["time"].Data, p.Time)
 		data["distance"].Data = append(data["distance"].Data, helpers.HumanDistance(ctx, p.TotalDistance))
 		data["duration"].Data = append(data["duration"].Data, p.TotalDuration.Seconds())


### PR DESCRIPTION
We now have nil-points in the data, because we care about the metadata.
This means we now need to filter those when drawing the map.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
