### PR TITLE
feat(i18n): add Swedish language support

### DIFF
--- a/frontend/lit-localize.json
+++ b/frontend/lit-localize.json
@@ -13,6 +13,7 @@
     "pl",
     "pt-BR",
     "ru",
+    "sv",
     "tr",
     "zh-Hans"
   ],

--- a/frontend/src/locale.ts
+++ b/frontend/src/locale.ts
@@ -18,6 +18,7 @@ export function initLocalize() {
         pl: () => import("./generated/locales/pl"),
         "pt-BR": () => import("./generated/locales/pt-BR"),
         ru: () => import("./generated/locales/ru"),
+        sv: () => import("./generated/locales/sv"),
         tr: () => import("./generated/locales/tr"),
         "zh-Hans": () => import("./generated/locales/zh-Hans"),
       })[locale](),

--- a/frontend/xliff/sv.xlf
+++ b/frontend/xliff/sv.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<file target-language="sv" source-language="en" original="lit-localize-inputs" datatype="plaintext">
+<body>
+<trans-unit id="translation.Tempo">
+  <source>Tempo</source>
+</trans-unit>
+<trans-unit id="translation.Total_up">
+  <source>Total up</source>
+</trans-unit>
+<trans-unit id="translation.Total_down">
+  <source>Total down</source>
+</trans-unit>
+</body>
+</file>
+</xliff>

--- a/translations/sv.yaml
+++ b/translations/sv.yaml
@@ -1,0 +1,5 @@
+---
+sv:
+  translation:
+    Welcome: Välkommen!
+

--- a/views/helpers/language.go
+++ b/views/helpers/language.go
@@ -33,6 +33,7 @@ var (
 		language.Russian,
 		language.SimplifiedChinese,
 		language.Spanish,
+		language.Swedish,
 		language.Turkish,
 	}
 )


### PR DESCRIPTION
Add Swedish to the list of supported locales across the frontend and backend.

Provide an initial translation file for Swedish to enable localization support
for Swedish-speaking users.

Fixes #809

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
