### PR TITLE
fix(auth): allow insecure token cookies

### DIFF
--- a/pkg/app/auth.go
+++ b/pkg/app/auth.go
@@ -36,10 +36,10 @@ func (a *App) createToken(u *database.User, c echo.Context) error {
 }
 
 func (a *App) setTokenCookie(t string, exp time.Time, c echo.Context) {
+	//nolint:gosec // Disable G124, allow insecure cookies
 	cookie := new(http.Cookie)
 	cookie.Path = "/"
 	cookie.HttpOnly = true
-	cookie.Secure = true
 	cookie.SameSite = http.SameSiteLaxMode
 	cookie.Name = "token"
 	cookie.Value = t


### PR DESCRIPTION
Remove the `Secure` attribute from the authentication token cookie to allow it
to be transmitted over unencrypted HTTP connections. This change is necessary
for environments where SSL/TLS is not terminated, such as local development
setups.

Add a `gosec` linter suppression directive (G124) to acknowledge the intentional
use of insecure cookies and prevent CI pipeline failures.

Fixes #820

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
