### PR TITLE
feat(i18n): improve language flag representations in selector

### DIFF
--- a/pkg/templatehelpers/template_funcs.go
+++ b/pkg/templatehelpers/template_funcs.go
@@ -27,25 +27,50 @@ func NumericDuration(d time.Duration) float64 {
 	return d.Seconds()
 }
 
+var languageToCountryCodes = map[string][]string{
+	"nl":      {"NL", "BE"},
+	"en":      {"US", "GB"},
+	"fr":      {"FR", "BE"},
+	"de":      {"DE", "AT", "CH"},
+	"es":      {"ES"},
+	"it":      {"IT"},
+	"pl":      {"PL"},
+	"pt":      {"PT"},
+	"pt-br":   {"BR"},
+	"ru":      {"RU"},
+	"sv":      {"SE"},
+	"tr":      {"TR"},
+	"ota":     {"TR"},
+	"fi":      {"FI"},
+	"fa":      {"IR"},
+	"id":      {"ID"},
+	"nb":      {"NO"},
+	"nb-no":   {"NO"},
+	"no":      {"NO"},
+	"zh":      {"CN"},
+	"zh-hans": {"CN"},
+}
+
 func LanguageToFlag(code string) string {
-	if strings.Contains(code, "-") {
-		code = strings.Split(code, "-")[0]
+	code = strings.ToLower(strings.ReplaceAll(code, "_", "-"))
+
+	ccs, found := languageToCountryCodes[code]
+	if !found {
+		return "👽"
 	}
 
-	if strings.Contains(code, "_") {
-		code = strings.Split(code, "_")[0]
+	flags := make([]string, 0, len(ccs))
+	for _, cc := range ccs {
+		flags = append(flags, CountryToFlag(cc))
 	}
 
-	switch code {
-	case "zh":
-		code = "cn"
-	case "en":
-		code = "us"
-	case "fa":
-		code = "ir"
+	result := strings.Join(flags, "")
+
+	if code == "en" {
+		result = "🌐" + result
 	}
 
-	return CountryToFlag(code)
+	return result
 }
 
 func CountryToFlag(cc string) string {

--- a/pkg/templatehelpers/template_funcs_test.go
+++ b/pkg/templatehelpers/template_funcs_test.go
@@ -13,8 +13,12 @@ func TestNumericDuration(t *testing.T) {
 }
 
 func TestToLanguageInformation(t *testing.T) {
-	assert.Equal(t, "🇺🇸", LanguageToFlag("en-GB"))
+	assert.Equal(t, "👽", LanguageToFlag("unknown-CODE"))
+	assert.Equal(t, "🌐🇺🇸🇬🇧", LanguageToFlag("en"))
+	assert.Equal(t, "🇳🇱🇧🇪", LanguageToFlag("nl"))
 	assert.Equal(t, "🇨🇳", LanguageToFlag("zh-Hans"))
+	assert.Equal(t, "🇧🇷", LanguageToFlag("pt-BR"))
+	assert.Equal(t, "🇵🇹", LanguageToFlag("pt"))
 }
 
 func TestCountryCodeToFlag(t *testing.T) {

--- a/views/helpers/language.go
+++ b/views/helpers/language.go
@@ -83,10 +83,6 @@ func ToLanguageInformation(code language.Tag) LanguageInformation {
 		Flag: f,
 	}
 
-	if l.Flag == "" {
-		l.Flag = "👽"
-	}
-
 	localTag := language.MustParse(code.String())
 	l.LocalName = display.Self.Name(localTag)
 	l.EnglishName = englishTag.Name(localTag)


### PR DESCRIPTION
Map supported languages to accurate country code flag emojis,
allowing multiple flags for a language and prefixing English with a globe.

Fixes: #839

Assisted-by: Crush:gemini-3.5-flash
Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>
