### PR TITLE
ui: show workouts as scatter dots in personal trend chart

### DIFF
--- a/frontend/src/views/route_segments/show_stats.ts
+++ b/frontend/src/views/route_segments/show_stats.ts
@@ -144,7 +144,7 @@ export class RouteSegmentStats extends LitElement {
         backgroundColor: colors.dot,
         borderColor: colors.dot,
         data: typeData,
-        showLine: true,
+        showLine: false,
         borderWidth: 2,
         pointRadius: 4,
         trendlineLinear: {


### PR DESCRIPTION
This changes the personal trend chart (segment) to not show lines between workouts. This makes it visually cleaner:

Before:

<img width="1368" height="519" alt="image" src="https://github.com/user-attachments/assets/f5b2f0c4-6f67-4987-bd75-69f4713dcb45" />

After:

<img width="1315" height="422" alt="image" src="https://github.com/user-attachments/assets/3f5f051f-2f07-45ab-a6b8-edb3dd151d7d" />
